### PR TITLE
Unzip exports to ~/.bin/ instead of current directory

### DIFF
--- a/nomad-introduction/courseBase.sh
+++ b/nomad-introduction/courseBase.sh
@@ -1,3 +1,3 @@
 curl -L http://assets.joinscrapbook.com/unzip -o ~/.bin/unzip && chmod +x ~/.bin/unzip
 curl -L -o ~/.bin/consul.zip https://releases.hashicorp.com/consul/0.9.0/consul_0.9.0_linux_amd64.zip
-unzip -d ~/.bin ~/.bin/consul.zip && chmod +x ~/.bin/consul
+unzip ~/.bin/consul.zip -d ~/.bin/ && chmod +x ~/.bin/consul


### PR DESCRIPTION
It should go to .bin.  Sorry, my mistake.