### PR TITLE
Remove lab numbers from Vault exercises

### DIFF
--- a/vault-auth/index.json
+++ b/vault-auth/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 6: Vault Authentication",
+  "title": "Vault Authentication",
   "description": "Learn how to enable and use username and password auth method.",
   "difficulty": "beginner",
   "time": "5 minutes",

--- a/vault-cubbyhole/index.json
+++ b/vault-cubbyhole/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 3: Vault Secret Engines - Cubbyhole",
+  "title": "Vault Secret Engines - Cubbyhole",
   "description": "Learn how cubbyhole secret engine works in Vault.",
   "difficulty": "beginner",
   "time": "5 minutes",

--- a/vault-identity/index.json
+++ b/vault-identity/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 7: Vault Identity - Entities & Groups",
+  "title": "Vault Identity - Entities & Groups",
   "description": "Learn how to create entities and groups in Vault.",
   "difficulty": "beginner",
   "time": "10 minutes",

--- a/vault-policies/index.json
+++ b/vault-policies/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 1: Vault ACL Policies",
+  "title": "Vault ACL Policies",
   "description": "Learn how to create Vault Policies to govern your environment.",
   "difficulty": "beginner",
   "time": "5 minutes",

--- a/vault-static-secrets/index.json
+++ b/vault-static-secrets/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 2: Vault Secret Engines - Versioned Key/Value",
+  "title": "Vault Secret Engines - Versioned Key/Value",
   "description": "Learn how to manage your secrets using Vault.",
   "difficulty": "beginner",
   "time": "10 minutes",

--- a/vault-tokens/index.json
+++ b/vault-tokens/index.json
@@ -1,6 +1,6 @@
 {
   "pathwayTitle": "Learn HashiCorp Vault",
-  "title": "Lab 5: Vault Token Lifecycle",
+  "title": "Vault Token Lifecycle",
   "description": "Learn the lifecycle of Vault client tokens.",
   "difficulty": "beginner",
   "time": "10 minutes",


### PR DESCRIPTION
This makes navigation clearer ("Vault" is the first word of the
tutorial) and allows practitioners to take any lab in any order.

We can recommend a sequence when linking to these tutorials from our own
guides and courses.

Do you think this is a good idea?