### PR TITLE
connect-adding-localhost: services failing DNS lookups on name localhost

### DIFF
--- a/consul-connect/courseBase.sh
+++ b/consul-connect/courseBase.sh
@@ -18,6 +18,7 @@ host_commands=(
 "cd /etc/consul.d && curl -L https://github.com/hashicorp/katakoda/raw/master/consul-connect/assets/config/dashboard.json -O"
 "mkdir -p /home/consul/log"
 "chown -R consul /home/consul"
+"echo '127.0.0.1 localhost' >> /etc/hosts"
 "runuser -l consul -c \"consul agent -dev -client 0.0.0.0 -config-dir=/etc/consul.d >/home/consul/log/consul.log 2>&1 &\""
 )
 


### PR DESCRIPTION
When running through the consul connect demo I noticed some service failures due to a hostname lookup issue on localhost.  Adding to /etc/hosts to allow lookups to not try to resolve via 8.8.8.8