### PR TITLE
Ubuntu environment path changes

### DIFF
--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -2,20 +2,20 @@
 # chmod +x ~/.bin/unzip
 
 curl -L -o ~/consul.zip https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_linux_amd64.zip
-unzip -d  ~/.bin/ ~/consul.zip
-chmod +x ~/.bin/consul
+unzip -d /usr/local/bin/ ~/consul.zip
+chmod +x /usr/local/bin/consul
 
 curl -L -o ~/nomad.zip https://releases.hashicorp.com/nomad/0.9.6/nomad_0.9.6_linux_amd64.zip
-unzip -d  ~/.bin/ ~/nomad.zip
-chmod +x  ~/.bin/nomad
+unzip -d  /usr/local/bin/ ~/nomad.zip
+chmod +x  /usr/local/bin/nomad
 
 curl -L -o ~/terraform.zip https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_linux_amd64.zip
-unzip -d ~/.bin ~/terraform.zip
-chmod +x ~/.bin/terraform
+unzip -d /usr/local/bin/ ~/terraform.zip
+chmod +x /usr/local/bin/terraform
 
 curl -L -o ~/vault.zip https://releases.hashicorp.com/vault/1.2.3/vault_1.2.3_linux_amd64.zip
-unzip -d ~/.bin ~/vault.zip
-chmod +x ~/.bin/vault
+unzip -d /usr/local/bin/ ~/vault.zip
+chmod +x /usr/local/bin/vault
 
 rm ~/nomad.zip ~/consul.zip ~/terraform.zip ~/vault.zip
 

--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -2,20 +2,20 @@
 # chmod +x ~/.bin/unzip
 
 curl -L -o ~/consul.zip https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_linux_amd64.zip
-unzip -d /usr/local/bin/ ~/consul.zip
-chmod +x /usr/local/bin/consul
+sudo unzip -d /usr/local/bin/ ~/consul.zip
+sudo chmod +x /usr/local/bin/consul
 
 curl -L -o ~/nomad.zip https://releases.hashicorp.com/nomad/0.9.6/nomad_0.9.6_linux_amd64.zip
-unzip -d  /usr/local/bin/ ~/nomad.zip
-chmod +x  /usr/local/bin/nomad
+sudo unzip -d  /usr/local/bin/ ~/nomad.zip
+sudo chmod +x  /usr/local/bin/nomad
 
 curl -L -o ~/terraform.zip https://releases.hashicorp.com/terraform/0.12.12/terraform_0.12.12_linux_amd64.zip
-unzip -d /usr/local/bin/ ~/terraform.zip
-chmod +x /usr/local/bin/terraform
+sudo unzip -d /usr/local/bin/ ~/terraform.zip
+sudo chmod +x /usr/local/bin/terraform
 
 curl -L -o ~/vault.zip https://releases.hashicorp.com/vault/1.2.3/vault_1.2.3_linux_amd64.zip
-unzip -d /usr/local/bin/ ~/vault.zip
-chmod +x /usr/local/bin/vault
+sudo unzip -d /usr/local/bin/ ~/vault.zip
+sudo chmod +x /usr/local/bin/vault
 
 rm ~/nomad.zip ~/consul.zip ~/terraform.zip ~/vault.zip
 


### PR DESCRIPTION
We've dropped the use of ~/.bin/ for Ubuntu as you can use the main /usr as the user is root. Update the path to ensure the binaries are in the $PATH automatically.