### PR TITLE
katacoda, display vault ui in iframe (no more new tab)

### DIFF
--- a/vault-auth/index.json
+++ b/vault-auth/index.json
@@ -40,12 +40,12 @@
     }
   },
   "environment": {
-      "uilayout": "terminal",
-      "showdashboard": true,
-      "dashboards": [
-        { "name": "Vault UI", "port": 8200 }
-      ],
-      "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    "uilayout": "terminal-iframe",
+    "showdashboard": true,
+    "dashboards": [
+      { "name": "Vault UI", "port": 8200 }
+    ],
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {
     "imageid": "hashicorp-hashistack"

--- a/vault-cubbyhole/index.json
+++ b/vault-cubbyhole/index.json
@@ -44,12 +44,12 @@
     }
   },
   "environment": {
-      "showdashboard": true,
-      "uilayout": "terminal",
-      "dashboards": [
-        { "name": "Vault UI", "port": 8200 }
-      ],
-      "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    "uilayout": "terminal-iframe",
+    "showdashboard": true,
+    "dashboards": [
+      { "name": "Vault UI", "port": 8200 }
+    ],
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {
     "imageid": "hashicorp-hashistack"

--- a/vault-playground-2/index.json
+++ b/vault-playground-2/index.json
@@ -23,7 +23,7 @@
     }
   },
   "environment": {
-    "uilayout": "terminal",
+    "uilayout": "terminal-iframe",
     "showdashboard": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }

--- a/vault-transit/index.json
+++ b/vault-transit/index.json
@@ -52,12 +52,12 @@
     }
   },
   "environment": {
-      "showdashboard": true,
-      "uilayout": "terminal",
-      "dashboards": [
-        { "name": "Vault UI", "port": 8200 }
-      ],
-      "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    "showdashboard": true,
+    "uilayout": "terminal-iframe",
+    "dashboards": [
+      { "name": "Vault UI", "port": 8200 }
+    ],
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {
     "imageid": "hashicorp-hashistack"


### PR DESCRIPTION
Currently, for vault scenarios, clicking on `Vault UI` in the terminal section will open up the vault UI in a new tab. This change opens it as an iframe (no more new tab)

example using generic template (hashicorp-hashistack image is private):
![image](https://user-images.githubusercontent.com/7556325/72388246-5086bf80-36da-11ea-8326-8ecae84940f3.png)
