### PR TITLE
Updated the version of Vault, Consul-Template, and Envconsul

### DIFF
--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -22,8 +22,8 @@ install_zip "nomad" "https://releases.hashicorp.com/nomad/0.10.1/nomad_0.10.1_li
 
 install_zip "terraform" "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_linux_amd64.zip"
 
-install_zip "vault" "https://releases.hashicorp.com/vault/1.3.1/vault_1.3.1_linux_amd64.zip"
+install_zip "vault" "https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linux_amd64.zip"
 
-install_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.22.1/consul-template_0.22.1_linux_amd64.zip"
+install_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.24.0/consul-template_0.24.0_linux_amd64.zip"
 
-install_zip "envconsul" "https://releases.hashicorp.com/envconsul/0.9.1/envconsul_0.9.1_linux_amd64.zip"
+install_zip "envconsul" "https://releases.hashicorp.com/envconsul/0.9.2/envconsul_0.9.2_linux_amd64.zip"

--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -16,11 +16,11 @@ install_zip()
     rm ~/$NAME.zip
 }
 
-install_zip "consul" "https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_linux_amd64.zip"
+install_zip "consul" "https://releases.hashicorp.com/consul/1.6.2/consul_1.6.2_linux_amd64.zip"
 
-install_zip "nomad" "https://releases.hashicorp.com/nomad/0.10.1/nomad_0.10.1_linux_amd64.zip"
+install_zip "nomad" "https://releases.hashicorp.com/nomad/0.10.2/nomad_0.10.2_linux_amd64.zip"
 
-install_zip "terraform" "https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_linux_amd64.zip"
+install_zip "terraform" "https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip"
 
 install_zip "vault" "https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linux_amd64.zip"
 


### PR DESCRIPTION
[Vault 1.3.2](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#132-january-22nd-2020) just got released which contains bug fixes. 

Also, I noticed that the version of [Consul-Template](https://releases.hashicorp.com/consul-template/) and [Envconsul](https://releases.hashicorp.com/envconsul/) are out-dated.  These tools are used by the [Direct App Integration](https://www.katacoda.com/hashicorp/scenarios/vault-tools) scenario, so this PR upgrades those tools as well. 