### PR TITLE
Install Sentinel CLI and Packer

### DIFF
--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -27,3 +27,7 @@ install_zip "vault" "https://releases.hashicorp.com/vault/1.3.2/vault_1.3.2_linu
 install_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.24.0/consul-template_0.24.0_linux_amd64.zip"
 
 install_zip "envconsul" "https://releases.hashicorp.com/envconsul/0.9.2/envconsul_0.9.2_linux_amd64.zip"
+
+install_zip "sentinel" "https://releases.hashicorp.com/sentinel/0.14.3/sentinel_0.14.3_linux_amd64.zip"
+
+install_zip "packer" "https://releases.hashicorp.com/packer/1.5.1/packer_1.5.1_linux_amd64.zip"


### PR DESCRIPTION
Adds CLI tools to baseline disk image in preparation for Sentinel interactive tutorials.