### PR TITLE
Adds the minikube scenario for Katacoda

### DIFF
--- a/vault-minikube/assets/deployment-01-webapp.yml
+++ b/vault-minikube/assets/deployment-01-webapp.yml
@@ -1,0 +1,29 @@
+---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: webapp
+    labels:
+      app: webapp
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: webapp
+    template:
+      metadata:
+        labels:
+          app: webapp
+      spec:
+        serviceAccountName: vault
+        containers:
+        - name: app
+          image: burtlo/exampleapp-ruby:k8s
+          imagePullPolicy: Always
+          env:
+          - name: VAULT_ADDR
+            value: "http://vault:8200"
+          - name: JWT_PATH
+            value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          - name: SERVICE_PORT
+            value: "8080"

--- a/vault-minikube/assets/helm-consul-values.yml
+++ b/vault-minikube/assets/helm-consul-values.yml
@@ -1,0 +1,11 @@
+global:
+  datacenter: vault-kubernetes-guide
+
+client:
+  enabled: true
+
+server:
+  replicas: 1
+  bootstrapExpect: 1
+  disruptionBudget:
+    maxUnavailable: 0

--- a/vault-minikube/assets/helm-vault-values.yml
+++ b/vault-minikube/assets/helm-vault-values.yml
@@ -1,0 +1,4 @@
+server:
+  affinity: ""
+  ha:
+    enabled: true

--- a/vault-minikube/courseBase.sh
+++ b/vault-minikube/courseBase.sh
@@ -1,0 +1,4 @@
+# Install Helm 3 and overwrite Helm 2
+curl -LO https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz
+tar -xvf helm-v3.2.1-linux-amd64.tar.gz
+mv linux-amd64/helm /usr/bin/

--- a/vault-minikube/finish.md
+++ b/vault-minikube/finish.md
@@ -1,0 +1,14 @@
+You launched Vault in high-availability mode with a Helm chart. Learn more about
+the Vault Helm chart by reading the
+[documentation](https://www.vaultproject.io/docs/platform/k8s/) or exploring the
+[project source code](https://github.com/hashicorp/vault-helm).
+
+Then you deployed a web application that authenticated and requested a secret
+directly from Vault. Explore how pods can retrieve secrets through the [Vault
+Injector service via annotations](/vault/getting-started-k8s/sidecar) or secrets
+[mounted on ephemeral volumes](/vault/getting-started-k8s/secret-store-driver).
+
+Finally, Consul is more than a storage backend for Vault. Explore running
+[Consul on Minikube via Helm](/consul/kubernetes/minikube) and its integrations
+with Kubernetes (including multi-cloud, service sync, and other features) in the
+[Consul documentation](https://consul.io/docs/platform/k8s/index.html).

--- a/vault-minikube/index.json
+++ b/vault-minikube/index.json
@@ -55,6 +55,7 @@
   },
   "environment": {
       "uilayout": "editor-terminal",
+      "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {

--- a/vault-minikube/index.json
+++ b/vault-minikube/index.json
@@ -1,0 +1,63 @@
+{
+  "pathwayTitle": "Learn HashiCorp Vault",
+  "title": "Vault Installation to Minikube via Helm",
+  "description": "Deploy Vault on Kubernetes locally using Minikube with the official Helm chart.",
+  "difficulty": "intermediate",
+  "time": "30 minutes",
+  "icon": "fa-vault",
+  "details": {
+    "steps": [
+      {
+        "title": "Start Minikube",
+        "text": "step1.md",
+        "courseData": "courseBase.sh"
+      },
+      {
+        "title": "Install the Consul Helm chart",
+        "text": "step2.md"
+      },
+      {
+        "title": "Install the Vault Helm chart",
+        "text": "step3.md"
+      },
+      {
+        "title": "Initialize and unseal Vault",
+        "text": "step4.md"
+      },
+      {
+        "title": "Set a secret in Vault",
+        "text": "step5.md"
+      },
+      {
+        "title": "Configure Kubernetes authentication",
+        "text": "step6.md"
+      },
+      {
+        "title": "Launch a web application",
+        "text": "step7.md"
+      }
+    ],
+    "intro": {
+      "text": "intro.md",
+      "credits": "https://learn.hashicorp.com/vault"
+    },
+    "assets": {
+      "host01": [
+        { "file": "helm-consul-values.yml", "target": "~/" },
+        { "file": "helm-vault-values.yml", "target": "~/" },
+        { "file": "deployment-01-webapp.yml", "target": "~/" }
+      ]
+    },
+    "finish": {
+      "text": "finish.md",
+      "credits": "https://learn.hashicorp.com/vault"
+    }
+  },
+  "environment": {
+      "uilayout": "editor-terminal",
+      "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+  },
+  "backend": {
+    "imageid": "minikube-running"
+  }
+}

--- a/vault-minikube/intro.md
+++ b/vault-minikube/intro.md
@@ -1,0 +1,10 @@
+Running Vault on [Kubernetes](https://kubernetes.io/) is generally the same as
+running it anywhere else. Kubernetes, as a container orchestration engine, eases
+some of the operational burdens and [Helm
+charts](https://helm.sh/docs/topics/charts/) provide the benefit of a
+refined interface when it comes to deploying Vault in a variety of different
+modes.
+
+In this tutorial, you will setup Vault and its dependencies with a Helm chart.
+Then integrate a web application that uses the Kubernetes service account token
+to authenticate with Vault and retrieve a secret.

--- a/vault-minikube/intro.md
+++ b/vault-minikube/intro.md
@@ -6,5 +6,5 @@ refined interface when it comes to deploying Vault in a variety of different
 modes.
 
 In this tutorial, you will setup Vault and its dependencies with a Helm chart.
-Then integrate a web application that uses the Kubernetes service account token
+Then you will integrate a web application that uses the Kubernetes service account token
 to authenticate with Vault and retrieve a secret.

--- a/vault-minikube/intro.md
+++ b/vault-minikube/intro.md
@@ -1,6 +1,6 @@
 Running Vault on [Kubernetes](https://kubernetes.io/) is generally the same as
 running it anywhere else. Kubernetes, as a container orchestration engine, eases
-some of the operational burdens and [Helm
+some of the operational burden and [Helm
 charts](https://helm.sh/docs/topics/charts/) provide the benefit of a
 refined interface when it comes to deploying Vault in a variety of different
 modes.

--- a/vault-minikube/step1.md
+++ b/vault-minikube/step1.md
@@ -1,0 +1,12 @@
+When you started this tutorial a Kubernetes cluster was already started for you.
+The initialization process takes several minutes as it retrieves any necessary
+dependencies and executes various container images.
+
+Verify the status of the Minikube cluster.
+
+```
+minikube status
+```{{execute}}
+
+When the host, kubelet, and apiserver report that they are `Running` the
+Kubernetes cluster is ready.

--- a/vault-minikube/step2.md
+++ b/vault-minikube/step2.md
@@ -1,0 +1,28 @@
+Consul's Helm chart by default starts more services than required to act as
+Vault's storage backend.
+
+Install the Consul Helm chart version 0.18.0 with pods prefixed with the name
+`consul` and apply the values found in `helm-consul-values.yml`{{open}}.
+
+```shell
+helm install consul \
+    --values helm-consul-values.yml \
+    https://github.com/hashicorp/consul-helm/archive/v0.18.0.tar.gz
+```{{execute}}
+
+The installation of the Helm chart displays the namespace, status, and resources
+created. The [server](https://www.consul.io/docs/glossary.html#server) and
+[client](https://www.consul.io/docs/glossary.html#client) pods are deployed in
+the `default` namespace because no namespace was specified or configured as the
+default.
+
+To verify, get all the pods within the `default` namespace.
+
+```shell
+kubectl get pods
+```{{execute}}
+
+The Consul services are displayed here as the pods prefixed with `consul`. The server
+and client report that they are
+[`Running`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)
+and ready (`1/1`).

--- a/vault-minikube/step2.md
+++ b/vault-minikube/step2.md
@@ -22,7 +22,7 @@ To verify, get all the pods within the `default` namespace.
 kubectl get pods
 ```{{execute}}
 
-The Consul services are displayed here as the pods prefixed with `consul`. The server
+Wait until the Consul services are displayed here as the pods prefixed with `consul`. The server
 and client report that they are
 [`Running`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)
 and ready (`1/1`).

--- a/vault-minikube/step2.md
+++ b/vault-minikube/step2.md
@@ -22,7 +22,8 @@ To verify, get all the pods within the `default` namespace.
 kubectl get pods
 ```{{execute}}
 
-Wait until the Consul services are displayed here as the pods prefixed with `consul`. The server
-and client report that they are
+The Consul services are displayed here as the pods prefixed with `consul`.
+
+Wait until the server and client report that they are
 [`Running`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase)
 and ready (`1/1`).

--- a/vault-minikube/step3.md
+++ b/vault-minikube/step3.md
@@ -1,0 +1,34 @@
+Vault's Helm chart by default launches with a file storage backend. To utilize
+the Consul cluster as a storage backend requires Vault to be run in
+high-availability mode.
+
+Install the Vault Helm chart version 0.4.0 with pods prefixed with the name
+`vault` and apply the values found in `helm-vault-values.yml`{{open}}.
+
+```shell
+helm install vault \
+    --values helm-vault-values.yml \
+    https://github.com/hashicorp/vault-helm/archive/v0.4.0.tar.gz
+```{{execute}}
+
+The Vault pod is deployed in the default namespace.
+
+To verify, get all the pods within the `default` namespace.
+
+```shell
+kubectl get pods
+```{{execute}}
+
+The `vault-0`, `vault-1` and `vault-2` pods report that they are `Running` but
+they are not ready `0/1`. That is because Vault in each pod is executes a status
+check defined in a [readinessProbe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+
+Retrieve the status of Vault on the `vault-0` pod.
+
+```shell
+kubectl exec vault-0 -- vault status
+```{{execute}}
+
+The [status command](https://www.vaultproject.io/docs/commands/status.html)
+reports that Vault is not initialized and that it is
+[sealed](https://www.vaultproject.io/docs/concepts/seal/#why).

--- a/vault-minikube/step3.md
+++ b/vault-minikube/step3.md
@@ -19,9 +19,13 @@ To verify, get all the pods within the `default` namespace.
 kubectl get pods
 ```{{execute}}
 
-The `vault-0`, `vault-1` and `vault-2` pods report that they are `Running` but
-they are not ready `0/1`. That is because Vault in each pod is executes a status
-check defined in a [readinessProbe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+
+The Vault pods are displayed as  `vault-0`, `vault-1` and `vault-2`.
+
+Wait until the pods report that they are `Running` and not ready (`0/1`).
+
+These pods are not ready because Vault in each pod executes a status
+check as a [readinessProbe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 
 Retrieve the status of Vault on the `vault-0` pod.
 

--- a/vault-minikube/step4.md
+++ b/vault-minikube/step4.md
@@ -1,0 +1,51 @@
+Initialize Vault with one key share and one key threshold.
+
+```shell
+kubectl exec vault-0 -- vault operator init -key-shares=1 -key-threshold=1 -format=json > cluster-keys.json
+```{{execute}}
+
+The [`operator
+init`](https://www.vaultproject.io/docs/commands/operator/init.html) command
+generates a master key that it disassembles into key shares `-key-shares=1` and
+then sets the number of key shares required to unseal Vault `-key-threshold=1`.
+These key shares are written to the output as unseal keys in JSON format
+`-format=json`. Here the output is redirected to a file named
+`cluster-keys.json`.
+
+View the unseal key found in `cluster-keys.json`.
+
+```shell
+cat cluster-keys.json | jq -r ".unseal_keys_b64[]"
+```{{execute}}
+
+Create a variable named VAULT_UNSEAL_KEY to capture the Vault unseal key.
+
+```shell
+VAULT_UNSEAL_KEY=$(cat cluster-keys.json | jq -r ".unseal_keys_b64[]")
+```{{execute}}
+
+Unseal Vault running on the `vault-0` pod.
+
+```shell
+kubectl exec vault-0 -- vault operator unseal $VAULT_UNSEAL_KEY
+```{{execute}}
+
+The `operator unseal` command reports that Vault is initialized and unsealed.
+
+Unseal Vault running on the `vault-1` pod.
+
+```shell
+kubectl exec vault-1 -- vault operator unseal $VAULT_UNSEAL_KEY
+```{{execute}}
+
+Unseal Vault running on the `vault-2` pod.
+
+```shell
+kubectl exec vault-2 -- vault operator unseal $VAULT_UNSEAL_KEY
+```{{execute}}
+
+Verify all the Vault pods are running and ready.
+
+```shell
+kubectl get pods
+```{{execute}}

--- a/vault-minikube/step4.md
+++ b/vault-minikube/step4.md
@@ -12,7 +12,7 @@ These key shares are written to the output as unseal keys in JSON format
 `-format=json`. Here the output is redirected to a file named
 `cluster-keys.json`.
 
-View the unseal key found in `cluster-keys.json`.
+View the unseal key found in `cluster-keys.json`{{open}}.
 
 ```shell
 cat cluster-keys.json | jq -r ".unseal_keys_b64[]"

--- a/vault-minikube/step5.md
+++ b/vault-minikube/step5.md
@@ -1,0 +1,47 @@
+Vault generated an initial [root
+token](https://www.vaultproject.io/docs/concepts/tokens.html#root-tokens) when
+it was initialized.
+
+View the root token found in `cluster-keys.json`.
+
+```shell
+cat cluster-keys.json | jq -r ".root_token"
+```{{execute}}
+
+First, start an interactive shell session on the `vault-0` pod.
+
+```shell
+kubectl exec -it vault-0 -- /bin/sh
+```{{execute}}
+
+Your system prompt is replaced with a new prompt `/ $`. Commands issued at this
+prompt are executed on the `vault-0` container.
+
+Vault is now ready for you to login with the initial root token.
+
+Login with the root token.
+
+```shell
+echo "When prompted for your Token copy & paste the token displayed above"
+vault login
+```{{execute}}
+
+Enable kv-v2 secrets at the path `secret`.
+
+```shell
+vault secrets enable -path=secret kv-v2
+```{{execute}}
+
+Create a secret at path `secret/webapp/config` with a `username` and `password`.
+
+```shell
+vault kv put secret/webapp/config username="static-user" password="static-password"
+```{{execute}}
+
+Verify that the secret is defined at the path `secret/webapp/config`.
+
+```shell
+vault kv get secret/webapp/config
+```{{execute}}
+
+You successfully created the secret for the web application.

--- a/vault-minikube/step6.md
+++ b/vault-minikube/step6.md
@@ -1,0 +1,52 @@
+Vault provides a [Kubernetes
+authentication](https://www.vaultproject.io/docs/auth/kubernetes.html) method
+that enables clients to authenticate with a Kubernetes Service Account
+Token.
+
+Enable the Kubernetes authentication method.
+
+```shell
+vault auth enable kubernetes
+```{{execute}}
+
+Configure the Kubernetes authentication method to use the service account
+token, the location of the Kubernetes host, and its certificate.
+
+```shell
+vault write auth/kubernetes/config \
+        token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+        kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
+        kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+```{{execute}}
+
+Write out the policy named `webapp` that enables the `read` capability for
+secrets at path `secret/data/webapp/config`.
+
+```shell
+vault policy write webapp - <<EOF
+path "secret/data/webapp/config" {
+  capabilities = ["read"]
+}
+EOF
+```{{execute}}
+
+Create a Kubernetes authentication role, named `webapp`, that connects the
+Kubernetes service account name and `webapp` policy.
+
+```shell
+vault write auth/kubernetes/role/webapp \
+        bound_service_account_names=vault \
+        bound_service_account_namespaces=default \
+        policies=webapp \
+        ttl=24h
+```{{execute}}
+
+The role connects the Kubernetes service account, `vault`, and namespace,
+`default`, with the Vault policy, `webapp`. The tokens returned after
+authentication are valid for 24 hours.
+
+Lastly, exit the `vault-0` pod.
+
+```shell
+exit
+```{{execute}}

--- a/vault-minikube/step7.md
+++ b/vault-minikube/step7.md
@@ -1,0 +1,39 @@
+Deploy the webapp in Kubernetes by applying the file `deployment-01-webapp.yml`{{open}}.
+
+```shell
+kubectl apply --filename deployment-01-webapp.yml
+```{{execute T1}}
+
+The web application runs as a pod within the `default` namespace.
+
+Get all the pods within the `default` namespace.
+
+```shell
+kubectl get pods
+```{{execute T1}}
+
+The web application pod is displayed here as the pod prefixed with `webapp`.
+
+This web application is running an HTTP service that is listening on port 8080.
+
+[Port
+forward](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward)
+all requests made to `http://localhost:8080` to the webapp pod on port 8080.
+
+```shell
+kubectl port-forward $(kubectl get pod -l app=webapp -o jsonpath="{.items[0].metadata.name}") 8080:8080
+```{{execute T2}}
+
+Perform a `curl` request at `http://localhost:8080`.
+
+```shell
+curl http://localhost:8080
+```{{execute T1}}
+
+The web application running on port 8080 in the _webapp_ pod:
+
+- authenticates with the Kubernetes service account token
+- receives a Vault token with the read capability at the
+  `secret/data/webapp/config` path
+- retrieves the secrets from `secret/data/webapp/config` path
+- displays the secrets as JSON

--- a/vault-minikube/step7.md
+++ b/vault-minikube/step7.md
@@ -14,6 +14,8 @@ kubectl get pods
 
 The web application pod is displayed here as the pod prefixed with `webapp`.
 
+Wait until the `webapp` status becomes **Running** and Ready (`1/1`).
+
 This web application is running an HTTP service that is listening on port 8080.
 
 [Port


### PR DESCRIPTION
Adds the scenario for https://learn.hashicorp.com/vault/kubernetes/minikube.

I stripped out a lot of the text from the original guide but I definitely could use a review to make sure it feels like the other scenarios.

Step 5 has the practitioner log in and needs them to copy & paste the root token. I wrote in an additional echo statement to hopefully make it clear what to paste. 