### PR TITLE
Configure all scenarios to hide dotfiles

### DIFF
--- a/consul-connect/index.json
+++ b/consul-connect/index.json
@@ -39,6 +39,7 @@
   },
   "environment": {
     "uilayout": "terminal",
+    "hideHiddenFiles": true,
     "uimessage1":
       "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands version 0.1.\u001b[m\r\n"
   },

--- a/nomad-connect-acls/index.json
+++ b/nomad-connect-acls/index.json
@@ -57,6 +57,7 @@
   "files": [],
   "environment": {
     "uilayout": "editor-terminal",
+    "hideHiddenFiles": true,
     "uimessage1": "\u001b[32mInteractive Bash Terminal.\u001b[m\r\n",
     "showdashboard": true,
     "dashboards": [

--- a/nomad-introduction/index.json
+++ b/nomad-introduction/index.json
@@ -40,6 +40,7 @@
   },
   "environment": {
     "uilayout": "editor-terminal",
+    "hideHiddenFiles": true,
     "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands version 0.1.\u001b[m\r\n"
   },
   "backend": {

--- a/nomad-openfaas/index.json
+++ b/nomad-openfaas/index.json
@@ -46,6 +46,7 @@
   },
   "environment": {
     "uilayout": "terminal",
+    "hideHiddenFiles": true,
     "showdashboard": true,
     "dashboards": [
       {"name": "Nomad", "port": 4646},

--- a/playground/index.json
+++ b/playground/index.json
@@ -17,6 +17,7 @@
   },
   "environment": {
     "uilayout": "editor-terminal",
+    "hideHiddenFiles": true,
     "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands version 0.1.\u001b[m\r\n"
   },
   "backend": {

--- a/terraform-consul-provider/index.json
+++ b/terraform-consul-provider/index.json
@@ -22,6 +22,7 @@
   },
   "environment": {
     "uilayout": "editor-terminal",
+    "hideHiddenFiles": true,
     "showdashboard": true,
     "dashboards": [
       {

--- a/vault-GS-first-secrets/index.json
+++ b/vault-GS-first-secrets/index.json
@@ -25,6 +25,7 @@
   },
   "environment": {
     "uilayout": "terminal",
+    "hideHiddenFiles": true,
     "showdashboard": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }

--- a/vault-GS-policy/index.json
+++ b/vault-GS-policy/index.json
@@ -33,6 +33,7 @@
   ],
   "environment": {
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"

--- a/vault-agent-templates/index.json
+++ b/vault-agent-templates/index.json
@@ -37,6 +37,7 @@
   },
   "environment": {
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"

--- a/vault-agent/index.json
+++ b/vault-agent/index.json
@@ -36,6 +36,7 @@
   },
   "environment": {
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"

--- a/vault-approle/index.json
+++ b/vault-approle/index.json
@@ -39,6 +39,7 @@
   },
   "environment": {
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"

--- a/vault-auth/index.json
+++ b/vault-auth/index.json
@@ -41,6 +41,7 @@
   },
   "environment": {
     "uilayout": "terminal-iframe",
+    "hideHiddenFiles": true,
     "showdashboard": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }

--- a/vault-auto-unseal/index.json
+++ b/vault-auto-unseal/index.json
@@ -38,6 +38,7 @@
   },
   "environment": {
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"

--- a/vault-cubbyhole/index.json
+++ b/vault-cubbyhole/index.json
@@ -46,6 +46,7 @@
   "environment": {
     "uilayout": "terminal-iframe",
     "showdashboard": true,
+    "hideHiddenFiles": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }
     ],

--- a/vault-dynamic-secrets/index.json
+++ b/vault-dynamic-secrets/index.json
@@ -50,6 +50,7 @@
   "environment": {
       "showdashboard": true,
       "uilayout": "terminal",
+      "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {

--- a/vault-ent-playground/index.json
+++ b/vault-ent-playground/index.json
@@ -25,6 +25,7 @@
   "environment": {
     "uilayout": "editor-terminal",
     "showdashboard": true,
+    "hideHiddenFiles": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }
     ],

--- a/vault-playground-2/index.json
+++ b/vault-playground-2/index.json
@@ -25,6 +25,7 @@
   "environment": {
     "uilayout": "terminal-iframe",
     "showdashboard": true,
+    "hideHiddenFiles": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }
     ],

--- a/vault-playground/index.json
+++ b/vault-playground/index.json
@@ -25,6 +25,7 @@
   "environment": {
     "uilayout": "editor-terminal",
     "showdashboard": true,
+    "hideHiddenFiles": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }
     ],

--- a/vault-policies/index.json
+++ b/vault-policies/index.json
@@ -47,6 +47,7 @@
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "dashboards": [
         { "name": "Vault UI", "port": 8200 }
       ],

--- a/vault-static-secrets/index.json
+++ b/vault-static-secrets/index.json
@@ -50,6 +50,7 @@
   "environment": {
       "showdashboard": true,
       "uilayout": "terminal",
+      "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {

--- a/vault-terraform/index.json
+++ b/vault-terraform/index.json
@@ -40,6 +40,7 @@
       "uilayout": "editor-terminal",
       "hideHiddenFiles": true,
       "showdashboard": true,
+      "hideHiddenFiles": true,
       "dashboards": [
         { "name": "Vault UI", "port": 8200 }
       ],

--- a/vault-tokens/index.json
+++ b/vault-tokens/index.json
@@ -58,6 +58,7 @@
   "environment": {
       "showdashboard": true,
       "uilayout": "terminal",
+      "hideHiddenFiles": true,
       "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
   },
   "backend": {

--- a/vault-transit/index.json
+++ b/vault-transit/index.json
@@ -54,6 +54,7 @@
   "environment": {
     "showdashboard": true,
     "uilayout": "terminal-iframe",
+    "hideHiddenFiles": true,
     "dashboards": [
       { "name": "Vault UI", "port": 8200 }
     ],


### PR DESCRIPTION
Dotfiles are shown by default but clutter the interface and aren't needed for
most scenarios. This commit hides them.