### PR TITLE
Add Docker automation

### DIFF
--- a/environments/hashistack/Dockerfile
+++ b/environments/hashistack/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+RUN  mkdir -p /stack
+COPY . /stack
+WORKDIR /stack
+
+ENV SHELL /bin/bash
+
+RUN apt-get update
+RUN apt-get update 
+RUN apt-get -y  install curl sudo unzip vim
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+
+RUN chmod +x /stack/build/*.sh 
+
+RUN echo "docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER docker
+RUN /stack/build/*.sh
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/environments/hashistack/Makefile
+++ b/environments/hashistack/Makefile
@@ -1,0 +1,28 @@
+PROJECT="katakoda"
+
+build: clean
+	@echo "==> Building katakoda image..."
+	@docker build \
+        --rm \
+        -t \
+		$(PROJECT):latest \
+        .
+run: build
+	@echo "==> Running katakoda container..."
+	docker run \
+	  -d \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  --name \
+	  $(PROJECT) \
+	  $(PROJECT)
+	@echo "==> Build complete, run command to continue:"
+	@echo "==> docker exec -it $(PROJECT) bash"
+
+clean:
+	@echo "==> Restting kayakoda container..."
+	docker ps | grep $(PROJECT) && docker rm -f $(PROJECT)
+
+.DEFAULT_GOAL := run 
+
+.PHONY: build
+.IGNORE: clean

--- a/environments/hashistack/README.md
+++ b/environments/hashistack/README.md
@@ -1,0 +1,68 @@
+# Running Stack in Docker
+
+The Dockerfile will build a ubuntu 16.0.4 image using the build scripts in this directory.
+
+## Quickstart 
+
+The following will create a fresh terminal session using the image:
+
+```shell
+make && docker exec -it katakoda bash
+```
+
+> The container is reset each time the make command is run.
+
+# Manual instructions
+
+Use these steps if you prefer to change or update the docker flags.
+
+Built the docker container
+
+```shell
+docker build \
+         --rm \
+         -t \
+         katakoda:latest
+```
+
+## Run Katakoda image.
+
+Launch the katakoda container in the background.
+
+```shell
+docker run \
+  -d \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --name \
+  katakoda \
+  katakoda
+```
+
+> The -v flag is optional but allows docker (in docker) to use the hosts docker api.
+
+## Run Katacoda scenerio 
+
+Connect to the katakoda container for interactive testing.
+
+
+```shell
+docker exec -it katakoda bash
+```
+
+## Resetting the container
+
+View the running containers
+
+```shell
+docker ps
+CONTAINER ID        IMAGE               COMMAND               CREATED             STATUS              PORTS               NAMES
+08a114d9aa4d        5fdc74d879ca        "tail -f /dev/null"   3 minutes ago       Up 3 minutes                            katakoda
+```
+
+Remove the running container
+
+```shell
+docker rm -f katakoda
+```
+
+> All session state will be lost.


### PR DESCRIPTION
Prior to this commit Katacoda scenarios needed to be ran from the web
ui. This commit adds an intial docker configuration to mirror this
configuration using our build stacks.