### PR TITLE
Katacoda Sentinel fixes

### DIFF
--- a/terraform-sentinel/index.json
+++ b/terraform-sentinel/index.json
@@ -20,7 +20,7 @@
           "text": "step1.md"
         },
         {
-          "title": "Add additonal policy requirements",
+          "title": "Add additional policy requirements",
           "text": "step2.md"
         },
         {

--- a/terraform-sentinel/index.json
+++ b/terraform-sentinel/index.json
@@ -39,6 +39,7 @@
   },
   "environment": {
     "uilayout": "editor-terminal",
+    "exclusionPatterns": ["Desktop"],
     "hideHiddenFiles": true,
     "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands version 0.1.\u001b[m\r\n"
   },

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -22,7 +22,7 @@ s3_buckets = filter tfplan.resource_changes as _, rc {
 
 ## Create the bucket rule
 
-Your policy has a filter that will search the mock data, but no rule to evaluate this data against. Copy and paste the `bucket_tags` rule below the commented line `# Rule to require at least one tag`.
+Add a rule to evaluate mock data. Copy and paste the `bucket_tags` rule below the commented line `# Rule to require at least one tag`.
 
 ```
 bucket_tags = rule {

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -10,7 +10,7 @@ For your first policy, create a resource filter for your S3 buckets and a rule t
 
 Open the stub of this policy in `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}}.
 
-The first step in this policy relies on creating a filter for the s3_bucket resources in the Terraform Cloud plan. Copy and paste the filter block below the commented line `# Filter S3 buckets`.
+Create a filter for the s3_bucket resources in the Terraform Cloud plan. Copy and paste the filter block below the commented line `# Filter S3 buckets`.
 
 ```
 s3_buckets = filter tfplan.resource_changes as _, rc {

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -8,7 +8,7 @@ For your first policy, create a resource filter for your S3 buckets and a rule t
 
 ## Create a filter
 
-The stub of this policy is in `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}}.
+Open the stub of this policy in `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}}.
 
 The first step in this policy relies on creating a filter for the s3_bucket resources in the Terraform Cloud plan. Copy and paste the filter block below the commented line `# Filter S3 buckets`.
 

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -15,8 +15,8 @@ Create a filter for the s3_bucket resources in the Terraform Cloud plan. Copy an
 ```
 s3_buckets = filter tfplan.resource_changes as _, rc {
 	rc.type is "aws_s3_bucket" and
-		(rc.change.actions contains "create" or rc.change.actions is ["update"])
-		}
+	(rc.change.actions contains "create" or rc.change.actions is ["update"])
+}
 ```{{copy}}
 
 
@@ -27,9 +27,9 @@ Add a rule to evaluate mock data. Copy and paste the `bucket_tags` rule below th
 ```
 bucket_tags = rule {
 	all s3_buckets as _, buckets {
-		buckets.change.after.tags is not null
-		}
+	buckets.change.after.tags is not null
 	}
+}
 ```{{copy}}
 
 

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -44,7 +44,7 @@ main = rule {
 }
 ```{{copy}}
 
-## Run your first apply
+## Apply the policy
 
 To see Sentinel policy logic in action, run an `apply` with the `trace` flag in your terminal.
 

--- a/terraform-sentinel/step1.md
+++ b/terraform-sentinel/step1.md
@@ -1,6 +1,6 @@
 In this scenario, you will apply the Sentinel Policy-as-Code principles to a Terraform specific deployment. You will create a policy that requires your configuration to have specific tags on your S3 buckets and restrict the level of access to your bucket objects.
 
-Open the file `~/terraform-sentinel/tf-config/main.tf`{{open}} and review the configuration you are testing.
+Open the file `terraform-sentinel/tf-config/main.tf`{{open}} and review the configuration you are testing.
 
 This configuration builds a publicly-readable S3 bucket with a unique name and deploys an example web app as a bucket object. The `acl` attribute of the `"aws_s3_bucket" "bucket"` resource ensures this web app object is public but the viewer cannot write or edit it.
 
@@ -8,7 +8,7 @@ For your first policy, create a resource filter for your S3 buckets and a rule t
 
 ## Create a filter
 
-The stub of this policy is in `~/terraform-sentinel/restrict-s3-buckets.sentinel`{{open}}.
+The stub of this policy is in `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}}.
 
 The first step in this policy relies on creating a filter for the s3_bucket resources in the Terraform Cloud plan. Copy and paste the filter block below the commented line `# Filter S3 buckets`.
 

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -34,7 +34,7 @@ Remove the print statement from your policy once you have reviewed the output.
 
 Open the policy file `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}} again.
 
-Copy and paste the `required_tags` variable below your filter statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that are required to be returned from the data you just generated in the previous print statement.
+Copy and paste the `required_tags` variable below your filter statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that must be returned from the data you just generated in the previous print statement.
 
 ```
 required_tags = [

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -92,7 +92,7 @@ main = rule {
 }
 ```{{copy}}
 
-## Run your apply 
+## Apply the policy 
 
 Run an apply in the Sentinel CLI again and evaluate the output. You should see that both the `acl_allowed` and `bucket_tags` rules evaluate to true, which allows your `main` rule to evaluate as true and the policy passes.
 

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -18,7 +18,7 @@ sentinel apply -trace restrict-s3-buckets.sentinel
 
 Copy the print statement output from your Sentinel apply, which will begin with `"{aws_bucket.bucket:..."` and end with `"..."type":"aws_s3_bucket")}"`. 
 
-Open the `terraform-sentinel/print.json`{{open}} file and paste the print output.
+Create a new file called `terraform-sentinel/print.json`{{touch}} and paste the print output there.
 
 Pipe the contents of this file to a `jq` command in your terminal to make this data easier to read.
 

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -49,9 +49,9 @@ Edit the `bucket_tags` rule to compare to your `require_tags` variable.
 
 ```
 bucket_tags = rule {
-	all s3_buckets as _, buckets {
-		all required_tags as rt {
-			buckets.change.after.tags contains rt
+all s3_buckets as _, buckets {
+	all required_tags as rt {
+		buckets.change.after.tags contains rt
 		}
 	}
 }
@@ -76,7 +76,7 @@ Copy and paste your ACL rule below your `allowed_acls` to evalute the ACL data i
 ```
 acl_allowed = rule {
 	all s3_buckets as _, buckets {
-		buckets.change.after.acl in allowed_acls
+	buckets.change.after.acl in allowed_acls
 	}
 }
 ```{{copy}}

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -18,7 +18,7 @@ sentinel apply -trace restrict-s3-buckets.sentinel
 
 Copy the print statement output from your Sentinel apply, which will begin with `"{aws_bucket.bucket:..."` and end with `"..."type":"aws_s3_bucket")}"`. 
 
-Open the `~/terraform-sentinel/print.json`{{open}} file and paste the print output.
+Open the `terraform-sentinel/print.json`{{open}} file and paste the print output.
 
 Pipe the contents of this file to a `jq` command in your terminal to make this data easier to read.
 
@@ -34,7 +34,7 @@ Remove the print statement from your policy once you have reviewed the output.
 
 Open the policy file `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}} again.
 
-Copy and paste the `required_tags` variable below your print statement in `~/terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that are required to be returned from the data you just generated in the previous print statement.
+Copy and paste the `required_tags` variable below your print statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that are required to be returned from the data you just generated in the previous print statement.
 
 ```
 required_tags = [

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -34,7 +34,7 @@ Remove the print statement from your policy once you have reviewed the output.
 
 Open the policy file `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}} again.
 
-Copy and paste the `required_tags` variable below your filter statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that must be returned from the data you just generated in the previous print statement.
+Copy and paste the `required_tags` variable below the `# Rule to require at least one tag` comment in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that must be returned from the data you just generated in the previous print statement.
 
 ```
 required_tags = [

--- a/terraform-sentinel/step2.md
+++ b/terraform-sentinel/step2.md
@@ -34,7 +34,7 @@ Remove the print statement from your policy once you have reviewed the output.
 
 Open the policy file `terraform-sentinel/restrict-s3-buckets.sentinel`{{open}} again.
 
-Copy and paste the `required_tags` variable below your print statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that are required to be returned from the data you just generated in the previous print statement.
+Copy and paste the `required_tags` variable below your filter statement in `terraform-sentinel/restrict-s3-policies.sentinel`{{open}}. You are creating a list of variables that are required to be returned from the data you just generated in the previous print statement.
 
 ```
 required_tags = [

--- a/terraform-sentinel/step3.md
+++ b/terraform-sentinel/step3.md
@@ -12,7 +12,7 @@ If you are having trouble finding the specific line in the collection, search fo
 
 ## Edit your mock data tags
 
-To create a failing scenario for your `bucket_tags` rule, replace the tag identifiers with different values. These tag identifiers search for an exact match so any additional text will cause a failure. 
+To create a failing scenario for your `bucket_tags` rule, replace the tag identifiers in the `resource_changes` collection with different values. These tag identifiers search for an exact match so any additional text will cause a failure. 
 
 If you have trouble finding the specific line, search for `<UPDATE_ID>` and replace it with `"FAIL-Environment"`{{copy}}
 

--- a/terraform-sentinel/step3.md
+++ b/terraform-sentinel/step3.md
@@ -2,7 +2,7 @@ In this step, you will edit your mock data structure to create a failing scenari
 
 ## Open the failing mock scenario for editing
 
-Open `~/terraform-sentinel/mock-data/mock-tfplan-fail-v2.sentinel`{{open}} and edit the values for your failing test. This file is a copy of your original mock data, but with a different file name to allow you to edit it with values that will cause your policy to fail. Creating a known "passing" and "failing" mock file in your mock-data directory keeps all your plan imports in the same folder structure.
+Open `terraform-sentinel/mock-data/mock-tfplan-fail-v2.sentinel`{{open}} and edit the values for your failing test. This file is a copy of your original mock data, but with a different file name to allow you to edit it with values that will cause your policy to fail. Creating a known "passing" and "failing" mock file in your mock-data directory keeps all your plan imports in the same folder structure.
 
 ## Edit your mock data ACL
 

--- a/terraform-sentinel/step3.md
+++ b/terraform-sentinel/step3.md
@@ -14,8 +14,6 @@ If you are having trouble finding the specific line in the collection, search fo
 
 To create a failing scenario for your `bucket_tags` rule, replace the tag identifiers in the `resource_changes` collection with different values. These tag identifiers search for an exact match so any additional text will cause a failure. 
 
-If you have trouble finding the specific line, search for `<UPDATE_ID>` and replace it with `"FAIL-Environment"`{{copy}}
-
-Search for `<UPDATE_ID>` and overwrite it with `"FAIL-Name"`{{copy}}
+If you have trouble finding the specific line, search for `<UPDATE_ID>`. Replace the first instance with `"FAIL-Environment"`{{copy}}, and the second with `"FAIL-Name"`{{copy}}.
 
 Now that you have failing mocked data, the next step will show you how to implement this in your failing tests.

--- a/terraform-sentinel/step3.md
+++ b/terraform-sentinel/step3.md
@@ -6,7 +6,7 @@ Open `terraform-sentinel/mock-data/mock-tfplan-fail-v2.sentinel`{{open}} and edi
 
 ## Edit your mock data ACL
 
-Your mock data contains the ACL for the configuration. Instead of `public-read`, which is allowed in your policy, change this to `public-read-write` to create a failing scenario for your `acl_allowed` rule. 
+Your mock data contains the ACL for the configuration in the `resource_changes` collection. Instead of `public-read`, which is allowed in your policy, change this to `public-read-write` to create a failing scenario for your `acl_allowed` rule. 
 
 If you are having trouble finding the specific line in the collection, search for `<UPDATE_VALUE>` in the file and overwrite it with `"public-read-write",`{{copy}}
 

--- a/terraform-sentinel/step3.md
+++ b/terraform-sentinel/step3.md
@@ -8,7 +8,7 @@ Open `terraform-sentinel/mock-data/mock-tfplan-fail-v2.sentinel`{{open}} and edi
 
 Your mock data contains the ACL for the configuration in the `resource_changes` collection. Instead of `public-read`, which is allowed in your policy, change this to `public-read-write` to create a failing scenario for your `acl_allowed` rule. 
 
-If you are having trouble finding the specific line in the collection, search for `<UPDATE_VALUE>` in the file and overwrite it with `"public-read-write",`{{copy}}
+If you are having trouble finding the specific line in the collection, search for `<UPDATE_VALUE>` in the file and overwrite it with `"public-read-write"`{{copy}}
 
 ## Edit your mock data tags
 

--- a/terraform-sentinel/step4.md
+++ b/terraform-sentinel/step4.md
@@ -5,7 +5,7 @@ In this step, you will create testing files and run them in the Sentinel CLI. Se
 
 Now that you have created a plan in which your Sentinel policy will fail, you need to create a test file for a failing test.
 
-Open `~terraform-sentinel/test/restrict-s3-buckets/fail.json`{{open}} to add a path to the failing mock data.
+Open `terraform-sentinel/test/restrict-s3-buckets/fail.json`{{open}} to add a path to the failing mock data.
 
 Copy and paste the failing mock data in your test file relative to your `fail.json` file, in this case, two directories above the current folder in `mock-data`.
 


### PR DESCRIPTION
This is getting there, just found a couple of things, some of which I didn't dig too far into (see below). Please merge before noon tomorrow so we can respect the code freeze. After it's merged it might be good to have someone test it one more time through to make sure that it's really bomb proof 🙂 

Additional comments: 

- [x] Looks like there's a `Desktop` folder in the root directory. Not sure what it's doing there 🤔 
- [x] Step 2: there is no `/terraform-sentinel/print.json` file