### PR TITLE
Refactor Consul Service Mesh Scenarios

### DIFF
--- a/consul-service-mesh-1/index.json
+++ b/consul-service-mesh-1/index.json
@@ -18,7 +18,7 @@
                 "text": "step1.md"
             },
             {
-                "title": "Download the Helm chart",
+                "title": "Deploy Consul service mesh with Helm",
                 "code": "set-env.sh",
                 "text": "step2.md"
             },
@@ -47,7 +47,6 @@
     },
     "environment": {
         "showdashboard": true,
-        "dashboard": "Dashboard",
         "uilayout": "editor-terminal",
         "hideHiddenFiles": true,
         "uimessage1": "\u001b[32mYour Interactive Bash Terminal.\u001b[m\r\n",

--- a/consul-service-mesh-1/step1.md
+++ b/consul-service-mesh-1/step1.md
@@ -1,13 +1,11 @@
 
-#### Start Minikube
-
 First, you need to start your Minikube environment:
 
-`minikube start --wait=false`{{execute}}
+`minikube start`{{execute}}
 
 This will create a local Kubernetes cluster using Minikube.
 
-#### Health Check
+#### Kubernetes cluster status check
 
 Once the first command has completed, check the state of your Kubernetes cluster.
 

--- a/consul-service-mesh-1/step2.md
+++ b/consul-service-mesh-1/step2.md
@@ -1,22 +1,49 @@
+
+Once the Kubernetes cluster is running, you can deploy Consul service mesh on it. In this hands-on lab you are going to use Helm for the deploy.
+
 #### Add HashiCorp repository to Helm
 
-Once Kubernetes is running, you can add the official HashiCorp Consul Helm chart repo directly from the command line.
+You can add the official HashiCorp Consul Helm chart repo directly from the command line.
 
 `helm repo add hashicorp https://helm.releases.hashicorp.com`{{execute}}
 
 The chart helps you automate the installation and configuration of Consul’s core features for Kubernetes.
 
+Ensure you have access to the consul chart after the add:
+
+`helm search repo hashicorp/consul`{{execute}}
+
+Example output:
+
+```
+NAME                    CHART VERSION   APP VERSION     DESCRIPTION
+hashicorp/consul        0.22.0          1.8.0           Official HashiCorp Consul Chart
+```
+
 #### Configure Consul service mesh
 
-This hands-on lab comes with a prepared configuration.
+The Helm chart has no required configuration and will install a Consul cluster with sane defaults out of the box. This is a good way to test the installation on a dev environment but real-life scenarios require customization to adapt the deploy to your needs.
+
+If you want to customize your installation, you can create a `.yaml` file to override the default settings and use it as a parameter for the intallation command. 
+
+This hands-on lab comes with a prepared configuration file.
 
 `consul-values.yml`{{open}}
 
 Note the following settings:
 
-* The server key contains parameters related to the server pods. The chart is configured to create one Consul server per Kubernetes node.
-* The Consul service mesh is enabled by setting the connectInject key to true. When the service mesh connect injector is installed, then a sidecar proxy is automatically added to all pods.
-* The ui section enables Consul web UI.
+* The `global` section is used to define settings applying to Consul datacenter. In the example configuration the datacenter name is set to *minidc*. Feel free to change that value before the deploy is you want to change your datacenter name.
+* The `server` key contains parameters related to the server pods. The chart is configured to create one Consul server per Kubernetes node.
+* The Consul service mesh is enabled by setting the `connectInject` key to true. When the service mesh connect injector is installed, then a sidecar proxy is automatically added to all pods.
+* The `ui` section enables Consul web UI.
+
+<div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
+  <p><strong>Info: </strong>
+
+The example in this lab modifies only few default settings.  You can learn what settings are available by running `helm inspect values hashicorp/consul` or by reading the [Helm Chart Reference](https://www.consul.io/docs/k8s/helm) available on the Consul documentation site.
+
+</p></div>
+
 
 #### Deploy Consul with Helm
 
@@ -26,11 +53,13 @@ You will use `helm install` to deploy Consul using the configuration defined in 
 
 #### Verify the Consul deployment
 
-Execute `kubectl get services` from the command line to verify the services, including Consul, are running in the Kubernetes cluster.
+Once the command terminates all components for Consul service mesh should be installed and initializing in your Kubernetes cluster.
+
+Execute `kubectl get services` from the command line to verify the services, including Consul, are present in the Kubernetes cluster.
 
 `kubectl get services`{{execute}}
 
-You should have the following four Consul services:
+You should have the following four Consul services available:
 
 * hashicorp-consul-server
 * hashicorp-consul-connect-injector-svc

--- a/consul-service-mesh-1/step2.md
+++ b/consul-service-mesh-1/step2.md
@@ -9,7 +9,7 @@ You can add the official HashiCorp Consul Helm chart repo directly from the comm
 
 The chart helps you automate the installation and configuration of Consul’s core features for Kubernetes.
 
-Ensure you have access to the consul chart after the add:
+Ensure you have access to the Consul chart after the add:
 
 `helm search repo hashicorp/consul`{{execute}}
 
@@ -22,7 +22,7 @@ hashicorp/consul        0.22.0          1.8.0           Official HashiCorp Consu
 
 #### Configure Consul service mesh
 
-The Helm chart has no required configuration and will install a Consul cluster with sane defaults out of the box. This is a good way to test the installation on a dev environment but real-life scenarios require customization to adapt the deploy to your needs.
+The Helm chart has no required configuration and will install a Consul datacenter with reasonable defaults out of the box. This is a good way to test the installation on a dev environment but real-life scenarios require customization to adapt the deployment to your needs.
 
 If you want to customize your installation, you can create a `.yaml` file to override the default settings and use it as a parameter for the intallation command. 
 
@@ -32,7 +32,7 @@ This hands-on lab comes with a prepared configuration file.
 
 Note the following settings:
 
-* The `global` section is used to define settings applying to Consul datacenter. In the example configuration the datacenter name is set to *minidc*. Feel free to change that value before the deploy is you want to change your datacenter name.
+* The `global` section is used to define settings applying to the entire Consul datacenter. In the example configuration the datacenter name is set to *minidc*. Feel free to change that value before the deploy if you want to change your datacenter name.
 * The `server` key contains parameters related to the server pods. The chart is configured to create one Consul server per Kubernetes node.
 * The Consul service mesh is enabled by setting the `connectInject` key to true. When the service mesh connect injector is installed, then a sidecar proxy is automatically added to all pods.
 * The `ui` section enables Consul web UI.
@@ -40,7 +40,7 @@ Note the following settings:
 <div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
   <p><strong>Info: </strong>
 
-The example in this lab modifies only few default settings.  You can learn what settings are available by running `helm inspect values hashicorp/consul` or by reading the [Helm Chart Reference](https://www.consul.io/docs/k8s/helm) available on the Consul documentation site.
+The example in this lab modifies only a few default settings.  You can learn what settings are available by running `helm inspect values hashicorp/consul` or by reading the [Helm Chart Reference](https://www.consul.io/docs/k8s/helm) available on the Consul documentation site.
 
 </p></div>
 

--- a/consul-service-mesh-1/step3.md
+++ b/consul-service-mesh-1/step3.md
@@ -1,10 +1,21 @@
+Depending on the resources of the Kubernetes cluster the Consul pods might take some time to initialize completely.
+
 #### Wait until all pods are running
 
 In order to access Consul you must verify the deploy was completed. Execute the following command, and review the output.
 
-`kubectl get pods --all-namespaces`{{execute}}
+`kubectl get pods`{{execute}}
 
-If the output shows all the pods in a `Running` state you can now configure your Kubernetes cluster to be accessed from outside.
+Example output:
+
+```
+NAME                                    READY   STATUS    RESTARTS   AGE
+hashicorp-consul-connect-injector...    1/1     Running   0          5m
+hashicorp-consul-ppdtk                  1/1     Running   0          5m
+hashicorp-consul-server-0               1/1     Running   0          5m
+```
+
+When the output shows all the pods in a `Running` status and ready, you can configure your Kubernetes cluster to be accessed from outside.
 
 #### Configure port forwarding for the Consul UI
 
@@ -18,6 +29,8 @@ This will forward port `80` from `service/hashicorp-consul-ui` at port `80` to y
 
 You can now open the Consul UI tab to be redirected to the Consul UI. The Consul UI will list
 the `consul` service.
+
+
 
 
 

--- a/consul-service-mesh-1/step3.md
+++ b/consul-service-mesh-1/step3.md
@@ -1,4 +1,4 @@
-Depending on the resources of the Kubernetes cluster the Consul pods might take some time to initialize completely.
+Depending on the resources of the Kubernetes cluster, the Consul pods might take some time to initialize completely.
 
 #### Wait until all pods are running
 
@@ -29,7 +29,6 @@ This will forward port `80` from `service/hashicorp-consul-ui` at port `80` to y
 
 You can now open the Consul UI tab to be redirected to the Consul UI. The Consul UI will list
 the `consul` service.
-
 
 
 

--- a/consul-service-mesh-2/index.json
+++ b/consul-service-mesh-2/index.json
@@ -47,7 +47,6 @@
     },
     "environment": {
         "showdashboard": true,
-        "dashboard": "Dashboard",
         "uilayout": "editor-terminal",
         "hideHiddenFiles": true,
         "uimessage1": "\u001b[32mYour Interactive Bash Terminal.\u001b[m\r\n",

--- a/consul-service-mesh-2/provision.courseData.sh
+++ b/consul-service-mesh-2/provision.courseData.sh
@@ -21,7 +21,7 @@ pushd ~
 
 log "Starting Kubernetes...this might take up to 5 minutes."
 
-minikube start --wait=true
+minikube start
 
 log "Installing Consul service mesh."
 
@@ -37,7 +37,7 @@ done
 
 export IP_ADDR=$(hostname -I | awk '{print $1}')
 
-kubectl port-forward service/hashicorp-consul-ui 80:80 --address ${IP_ADDR} &
+kubectl port-forward service/hashicorp-consul-ui 80:80 --address ${IP_ADDR} > /tmp/forward_consul_ui.log 2>&1 &
 
 finish
 

--- a/consul-service-mesh-2/step1.md
+++ b/consul-service-mesh-2/step1.md
@@ -1,4 +1,4 @@
-To test Consul service mesh you will deploy two simple services, `api` and `web`. The two services represent a simple two-tier application made of a backend api service and a frontend that communicates with the api service over HTTP and exposes the results in a web ui.
+To test the Consul service mesh you will deploy two simple services, `api` and `web`. The two services represent a simple two-tier application made of a backend api service and a frontend that communicates with the api service over HTTP and exposes the results in a web ui.
 
 #### Review the backend service configuration
 

--- a/consul-service-mesh-2/step1.md
+++ b/consul-service-mesh-2/step1.md
@@ -1,10 +1,8 @@
-#### Deploy services into Consul service mesh
-
-The two services represent a simple two-tier application made of a backend api service and a frontend that communicates with the api service over HTTP and exposes the results in a web ui.
+To test Consul service mesh you will deploy two simple services, `api` and `web`. The two services represent a simple two-tier application made of a backend api service and a frontend that communicates with the api service over HTTP and exposes the results in a web ui.
 
 #### Review the backend service configuration
 
-This hands-on lab comes with a prepared configuration.
+This hands-on lab comes with a prepared configuration for the `api` service.
 
 `api.yml`{{open}}
 
@@ -26,4 +24,11 @@ Wait until the pod is marked as `Running` to continue. This might take up to a m
 
 ### Verify application status in Consul UI
 
-Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui/minidc/services) and ensure two services `api` and `api-sidecar-proxy` are registered and healthy in Consul.
+Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui) and ensure the services `api` is registered and healthy in Consul.
+
+<div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
+  <p><strong>Info: </strong>
+  
+  In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "service_name-sidecar-proxy".
+
+</p></div>

--- a/consul-service-mesh-2/step2.md
+++ b/consul-service-mesh-2/step2.md
@@ -1,13 +1,11 @@
-#### Deploy frontend service in your service mesh
+Next you are going to deploy the frontend service.
 
 This hands-on lab comes with a prepared configuration.
 
 `web.yml`{{open}}
 
 In additon to the `"consul.hashicorp.com/connect-inject": "true"` annotation, the
-`web` service defines the `"consul.hashicorp.com/connect-service-upstreams"` annotation. This annotation
- explicitly declares the upstream for the web service, which is the `api` service you deployed
- previously.
+`web` service defines the `"consul.hashicorp.com/connect-service-upstreams"` annotation. This annotation  explicitly declares the upstream for the web service, which is the `api` service you deployed previously.
 
 #### Deploy app with kubectl
 
@@ -25,4 +23,11 @@ Wait until the pod is marked as `Running` to continue. This might take up to a m
 
 ### Verify application status in Consul UI
 
-Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui/minidc/services) and ensure two services `api` and `api-sidecar-proxy` are registered and healthy in Consul.
+Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui) and ensure the service `web` is registered and healthy in Consul.
+
+<div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
+  <p><strong>Info: </strong>
+  
+  In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "service_name-sidecar-proxy".
+
+</p></div>

--- a/consul-service-mesh-2/step3.md
+++ b/consul-service-mesh-2/step3.md
@@ -1,3 +1,5 @@
+To access a service running inside a Kubernetes cluster you will have to expose the service to an external network.
+
 #### Configure port forwarding for your frontend service
 
 To access the app running inside your Consul service mesh, you will setup port forwarding.

--- a/consul-service-mesh-3/finish.md
+++ b/consul-service-mesh-3/finish.md
@@ -14,5 +14,5 @@ Specifically you:
 
 # Next Steps
 
-To learn more about Consul service mesh, [understand Consul service mesh](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh) provides a reference guide for the Consul service mesh based labs.
+To learn more about Consul service mesh, [Understand Consul Service Mesh](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh) provides a reference guide for the Consul service mesh based labs.
 

--- a/consul-service-mesh-3/index.json
+++ b/consul-service-mesh-3/index.json
@@ -47,7 +47,6 @@
     },
     "environment": {
         "showdashboard": true,
-        "dashboard": "Dashboard",
         "uilayout": "editor-terminal",
         "hideHiddenFiles": true,
         "uimessage1": "\u001b[32mYour Interactive Bash Terminal.\u001b[m\r\n",

--- a/consul-service-mesh-3/provision.courseData.sh
+++ b/consul-service-mesh-3/provision.courseData.sh
@@ -21,7 +21,7 @@ pushd ~
 
 log "Starting Kubernetes...this might take up to 5 minutes."
 
-minikube start --wait=true
+minikube start
 
 log "Installing Consul service mesh."
 
@@ -39,7 +39,7 @@ log "Adding port forward for Consul UI"
 
 export IP_ADDR=$(hostname -I | awk '{print $1}')
 
-kubectl port-forward service/hashicorp-consul-ui 80:80 --address ${IP_ADDR} &
+kubectl port-forward service/hashicorp-consul-ui 80:80 --address ${IP_ADDR} > /tmp/forward_consul_ui.log 2>&1 &
 
 
 log "Deploying api backend."
@@ -61,7 +61,7 @@ log "Adding port forward for Web UI"
 
 export IP_ADDR=$(hostname -I | awk '{print $1}')
 
-kubectl port-forward service/web 9090:9090 --address ${IP_ADDR} &
+kubectl port-forward service/web 9090:9090 --address ${IP_ADDR} > /tmp/forward_web.log 2>&1 &
 
 finish
 

--- a/consul-service-mesh-3/step1.md
+++ b/consul-service-mesh-3/step1.md
@@ -1,14 +1,26 @@
 #### Check Consul is up and running
 
-Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui/minidc/services) and ensure four services are registered and healthy in Consul 
-* `api` 
-* `api-sidecar-proxy`
-* `web`
-* `web-sidecar-proxy` 
+Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/ui) and ensure services `web` and `api` are registered and healthy in Consul.
+
+<div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
+  <p><strong>Info: </strong>
+  
+    In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "<service_name>-sidecar-proxy".
+
+</p></div>
 
 Open the [Dashboard](https://[[HOST_SUBDOMAIN]]-9090-[[KATACODA_HOST]].environments.katacoda.com/ui) tab to be redirected to the web application UI.
 
 ### Connect to Consul container
 
-To create a zero-trust network you will need to manage Consul intentions, which allow or deny service communication. The first step is to connect to the Kubernetes container with the Consul server. 
+To create a zero-trust network you will need to manage Consul intentions, which allow or deny service communication. The first step is to connect to the Kubernetes container with the Consul server.
+
 `kubectl exec -it hashicorp-consul-server-0 /bin/sh`{{execute}}
+
+
+<div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
+  <p><strong>Info:</strong>
+  
+  Consul intentions can also be managed using the UI or the API interface.
+
+</p></div>

--- a/consul-service-mesh-3/step1.md
+++ b/consul-service-mesh-3/step1.md
@@ -5,7 +5,7 @@ Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.ka
 <div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
   <p><strong>Info: </strong>
   
-    In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "service_name-sidecar-proxy".
+    In Consul 1.8 a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "service_name-sidecar-proxy".
 
 </p></div>
 

--- a/consul-service-mesh-3/step1.md
+++ b/consul-service-mesh-3/step1.md
@@ -5,7 +5,7 @@ Open [Consul UI](https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.ka
 <div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
   <p><strong>Info: </strong>
   
-    In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "<service_name>-sidecar-proxy".
+    In Consul 1.8.x a service deployed correctly into the service mesh will have "connected with proxy" in its description. Prior versions of Consul will have an additional service named "service_name-sidecar-proxy".
 
 </p></div>
 

--- a/consul-service-mesh-3/step3.md
+++ b/consul-service-mesh-3/step3.md
@@ -6,7 +6,6 @@ Now that all service communication is denied by default, the web service can no 
 
 You can confirm that the services cannot communicate from the [Dashboard](https://[[HOST_SUBDOMAIN]]-9090-[[KATACODA_HOST]].environments.katacoda.com/ui) tab. Both services will be displayed in red boxes. 
 
-
 #### Enable connectivity
 
 Now, you will need to create a Consul intention to allow communication between the services. 


### PR DESCRIPTION
* Modified commands for minikube to remove unsupported `--wait` option
* Added some more context
* The lab now deploys Consul 1.8 after release. UI changed so added call-outs to specify differences
* In scenario 2 and 3 redirected all output of port forward in the initial deploy to log to don't litter the shell

Tried to move away from `minikube` environment but the same commands would not work so I decided not to risk.

Preview:

* Lab 1: https://katacoda.com/danielehc/scenarios/consul-service-mesh-1
* Lab 2:https://katacoda.com/danielehc/scenarios/consul-service-mesh-2
* Lab 3: https://katacoda.com/danielehc/scenarios/consul-service-mesh-3