### PR TITLE
Updates vault k8s csi courseBase

### DIFF
--- a/vault-kubernetes-csi/courseBase.sh
+++ b/vault-kubernetes-csi/courseBase.sh
@@ -1,3 +1,11 @@
+# Update minikube version
+sudo minikube delete
+sudo apt install conntrack -y
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+  && chmod +x minikube
+sudo mkdir -p /usr/local/bin/
+sudo install minikube /usr/local/bin/
+
 # Install kubectl v1.18.0
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
 chmod +x kubectl

--- a/vault-kubernetes-csi/step1.md
+++ b/vault-kubernetes-csi/step1.md
@@ -5,7 +5,7 @@ dependencies and executes various container images.
 Start the Minikube cluster.
 
 ```shell
-minikube start
+minikube start --vm-driver none --bootstrapper kubeadm
 ```{{execute}}
 
 Verify the status of the Minikube cluster.

--- a/vault-kubernetes-csi/step3.md
+++ b/vault-kubernetes-csi/step3.md
@@ -7,7 +7,7 @@ the path `/secret`.
 First, start an interactive shell session on the `vault-0` pod.
 
 ```shell
-kubectl exec -it vault-0 /bin/sh
+kubectl exec -it vault-0 -- /bin/sh
 ```{{execute}}
 
 Your system prompt is replaced with a new prompt `/ $`. Commands issued at this


### PR DESCRIPTION
- The minikube version needs an update
- Starting it requires more flags to use the right bootstrapper
- Fixes command generating error