### PR TITLE
Adds courseBase to sidecar and command to wait

### DIFF
--- a/vault-kubernetes-csi/courseBase.sh
+++ b/vault-kubernetes-csi/courseBase.sh
@@ -1,5 +1,8 @@
-# Update minikube version
+# Hide the existing minikube
 sudo minikube delete
+mv /usr/local/bin/minikube /usr/local/bin/minikube-old
+
+# Update minikube version
 sudo apt install conntrack -y
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
   && chmod +x minikube

--- a/vault-kubernetes-csi/step1.md
+++ b/vault-kubernetes-csi/step1.md
@@ -2,6 +2,14 @@ When you started this tutorial a Kubernetes cluster was already started for you.
 The initialization process takes several minutes as it retrieves any necessary
 dependencies and executes various container images.
 
+Verify the `minikube` CLI is installed.
+
+```shell
+minikube version
+```{{execute}}
+
+Wait until the `minikube version` command returns a value.
+
 Start the Minikube cluster.
 
 ```shell

--- a/vault-kubernetes-sidecar/courseBase.sh
+++ b/vault-kubernetes-sidecar/courseBase.sh
@@ -1,3 +1,14 @@
+# Hide the existing minikube
+sudo minikube delete
+mv /usr/local/bin/minikube /usr/local/bin/minikube-old
+
+# Update minikube version
+sudo apt install conntrack -y
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+  && chmod +x minikube
+sudo mkdir -p /usr/local/bin/
+sudo install minikube /usr/local/bin/
+
 # Install kubectl v1.18.0
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
 chmod +x kubectl

--- a/vault-kubernetes-sidecar/step1.md
+++ b/vault-kubernetes-sidecar/step1.md
@@ -2,10 +2,18 @@ When you started this tutorial a Kubernetes cluster was already started for you.
 The initialization process takes several minutes as it retrieves any necessary
 dependencies and executes various container images.
 
+Verify the `minikube` CLI is installed.
+
+```shell
+minikube version
+```{{execute}}
+
+Wait until the `minikube version` command returns a value.
+
 Start the Minikube cluster.
 
 ```shell
-minikube start
+minikube start --vm-driver none --bootstrapper kubeadm
 ```{{execute}}
 
 Verify the status of the Minikube cluster.


### PR DESCRIPTION
- both coursebases use the same setup to upgrade kubernetes
- both start with a command to verify that the minikube executable is
  ready