### PR TITLE
Removes extra terminals from being made in Vault SSH OTP scenario

### DIFF
--- a/vault-sm-ssh-otp/index.json
+++ b/vault-sm-ssh-otp/index.json
@@ -35,17 +35,7 @@
     }
   },
   "environment": {
-    "uilayout": "terminal-terminal",
-    "terminals": [
-      {
-        "name": "vault-server",
-        "target": "HOST1"
-      },
-      {
-        "name": "remote-host",
-        "target": "HOST2"
-      }
-    ]
+    "uilayout": "terminal-terminal"
   },
   "backend": {
     "imageid": "hashicorp-hashistack-cluster"


### PR DESCRIPTION
With the terminal-terminal view specifying the names of the terminals instead creates new terminals instead of renaming the existing ones. The targets were right and each terminal was the right host but there is no need for four terminals.