### PR TITLE
Vault PKI Engine Scenario

### DIFF
--- a/vault-pki-engine/assets/scenario-policy.hcl
+++ b/vault-pki-engine/assets/scenario-policy.hcl
@@ -1,0 +1,14 @@
+# Enable secrets engine
+path "sys/mounts/*" {
+  capabilities = [ "create", "read", "update", "delete", "list" ]
+}
+
+# List enabled secrets engine
+path "sys/mounts" {
+  capabilities = [ "read", "list" ]
+}
+
+# Work with pki secrets engine
+path "pki*" {
+  capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
+}

--- a/vault-pki-engine/finish.md
+++ b/vault-pki-engine/finish.md
@@ -1,0 +1,12 @@
+Check out the [Streamline Certificate Management with HashiCorp
+Vault](https://www.hashicorp.com/resources/streamline-certificate-management-with-vault)
+webinar recording.
+
+<VideoEmbed url="https://youtu.be/k8FXTeFCp90" />
+
+Also, refer to the [Vault PKI Secrets Engine
+Integration](https://www.nomadproject.io/guides/security/vault-pki-integration.html)
+guide for an example of Nomad using the PKI secrets engine to generate and renew
+the X.509 certificates it uses. To automate the process, this guide leverages
+the [Consul Template](https://github.com/hashicorp/consul-template) tool.
+

--- a/vault-pki-engine/index.json
+++ b/vault-pki-engine/index.json
@@ -1,0 +1,51 @@
+{
+  "pathwayTitle": "Learn HashiCorp Vault",
+  "title": "Build Your Own Certificate Authority (CA)",
+  "description": "Use the PKI secrets engine to generate dynamic X.509 certificates.",
+  "difficulty": "intermediate",
+  "time": "30 minutes",
+  "icon": "fa-vault",
+  "details": {
+    "steps": [
+      {
+        "title": "Generate Root CA",
+        "text": "step1.md",
+        "courseData": "step1.setup.sh"
+      },
+      {
+        "title": "Generate Intermediate CA",
+        "text": "step2.md"
+      },
+      {
+        "title": "Create a Role",
+        "text": "step3.md"
+      },
+      {
+        "title": "Request Certificates",
+        "text": "step4.md"
+      },
+      {
+        "title": "Revoke Certificates",
+        "text": "step5.md"
+      },
+      {
+        "title": "Remove Expired Certificates",
+        "text": "step6.md"
+      }
+    ],
+    "intro": {
+      "text": "intro.md"
+    },
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "environment": {
+    "showdashboard": true,
+    "uilayout": "terminal",
+    "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+  },
+  "backend": {
+    "imageid": "hashicorp-hashistack"
+  }
+}

--- a/vault-pki-engine/index.json
+++ b/vault-pki-engine/index.json
@@ -6,11 +6,20 @@
   "time": "30 minutes",
   "icon": "fa-vault",
   "details": {
+    "assets": {
+      "host01": [
+        { "file": "scenario-policy.hcl", "target": "~/" }
+      ]
+    },
     "steps": [
       {
+        "title": "Connect to Vault",
+        "text": "step0.md",
+        "courseData": "step0.setup.sh"
+      },
+      {
         "title": "Generate Root CA",
-        "text": "step1.md",
-        "courseData": "step1.setup.sh"
+        "text": "step1.md"
       },
       {
         "title": "Generate Intermediate CA",
@@ -43,7 +52,13 @@
   "environment": {
     "showdashboard": true,
     "uilayout": "terminal",
-    "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    "dashboards": [
+      {
+        "name": "UI",
+        "href": "https://[[HOST_SUBDOMAIN]]-8200-[[KATACODA_HOST]].environments.katacoda.com"
+      }
+    ]
+
   },
   "backend": {
     "imageid": "hashicorp-hashistack"

--- a/vault-pki-engine/intro.md
+++ b/vault-pki-engine/intro.md
@@ -1,0 +1,8 @@
+Vault's PKI secrets engine can dynamically generate X.509 certificates on
+demand. This allows services to acquire certificates without the manual process
+of generating a private key and Certificate Signing Request (CSR), submitting to
+a CA, and then waiting for the verification and signing process to complete.
+
+In this tutorial, you generate a self-signed root certificate. Then you generate
+an intermediate certificate which is signed by the root. Finally, you generate a
+certificate for the `test.example.com` domain.

--- a/vault-pki-engine/step0.md
+++ b/vault-pki-engine/step0.md
@@ -1,0 +1,23 @@
+Connect to the target Vault server.
+
+Export an environment variable for the `vault` CLI to address the target Vault server.
+
+```shell
+export VAULT_ADDR=http://0.0.0.0:8200
+```{{execute}}
+
+View the policies required to perform the scenario.
+
+```shell
+cat scenario-policy.hcl
+```{{execute}}
+
+Login with `userpass` authentication with the `scenario-user`.
+
+```shell
+vault login -method=userpass \
+  username=scenario-user \
+  password=scenario-password
+```{{execute}}
+
+The environment is ready. Proceed to the next step.

--- a/vault-pki-engine/step0.setup.sh
+++ b/vault-pki-engine/step0.setup.sh
@@ -23,7 +23,20 @@ sudo systemctl start vault
 
 sleep 5
 
-export VAULT_ADDR=http://0.0.0.0:8200
 ufw allow 8200/tcp
 
+export VAULT_ADDR=http://0.0.0.0:8200
+
+# Login as root and create a userauth endpoint for the scenario.
+
 vault login root
+
+vault policy write scenario-policy scenario-policy.hcl
+
+vault auth enable userpass
+
+vault write auth/userpass/users/scenario-user \
+  password=scenario-password \
+  policies=scenario-policy
+
+rm /root/.vault-token

--- a/vault-pki-engine/step1.md
+++ b/vault-pki-engine/step1.md
@@ -1,0 +1,35 @@
+Generate a self-signed certificate authority (CA) root certificate using PKI
+secrets engine.
+
+Enable the `pki` secrets engine at the `pki` path.
+
+```shell
+vault secrets enable pki
+```{{execute}}
+
+Tune the `pki` secrets engine to issue certificates with a maximum time-to-live
+(TTL) of `87600` hours.
+
+```shell
+vault secrets tune -max-lease-ttl=87600h pki
+```{{execute}}
+
+Generate the **_root_** certificate and save the certificate in `CA_cert.crt`.
+
+```shell
+vault write -field=certificate pki/root/generate/internal \
+  common_name="example.com" \
+  ttl=87600h > CA_cert.crt
+```{{execute}}
+
+This generates a new self-signed CA certificate and private key. Vault
+_automatically_ revokes the generated root at the end of its lease period (TTL);
+the CA certificate will sign its own Certificate Revocation List (CRL).
+
+Configure the CA and CRL URL.
+
+```shell
+vault write pki/config/urls \
+  issuing_certificates="http://127.0.0.1:8200/v1/pki/ca" \
+  crl_distribution_points="http://127.0.0.1:8200/v1/pki/crl"
+```{{execute}}

--- a/vault-pki-engine/step1.setup.sh
+++ b/vault-pki-engine/step1.setup.sh
@@ -1,0 +1,23 @@
+sudo tee /etc/systemd/system/vault.service > /dev/null <<EOF
+[Unit]
+Description=Vault
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+PermissionsStartOnly=true
+ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
+ExecStart=/usr/local/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200
+ExecReload=/bin/kill -HUP \$MAINPID
+KillSignal=SIGTERM
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl enable vault
+sudo systemctl start vault
+ufw allow 8200/tcp

--- a/vault-pki-engine/step2.md
+++ b/vault-pki-engine/step2.md
@@ -1,0 +1,38 @@
+Create an intermediate CA using the root CA you generated.
+
+Enable the `pki` secrets engine at the `pki_int` path.
+
+```shell
+vault secrets enable -path=pki_int pki
+```{{execute}}
+
+Tune the `pki_int` secrets engine to issue certificates with a maximum
+time-to-live (TTL) of `43800` hours.
+
+```shell
+vault secrets tune -max-lease-ttl=43800h pki_int
+```{{execute}}
+
+Generate an intermediate certificate signing request (CSR) and save and save it
+in `pki_intermediate.csr`.
+
+```shell
+vault write -format=json pki_int/intermediate/generate/internal \
+        common_name="example.com Intermediate Authority" \
+        | jq -r '.data.csr' > pki_intermediate.csr
+```{{execute}}
+
+Sign the intermediate CSR with the root certificate and save the generated
+certificate as `intermediate.cert.pem`.
+
+```shell
+vault write -format=json pki/root/sign-intermediate csr=@pki_intermediate.csr \
+        format=pem_bundle ttl="43800h" \
+        | jq -r '.data.certificate' > intermediate.cert.pem
+```{{execute}}
+
+Import the signed certificate into Vault.
+
+```shell
+vault write pki_int/intermediate/set-signed certificate=@intermediate.cert.pem
+```{{execute}}

--- a/vault-pki-engine/step3.md
+++ b/vault-pki-engine/step3.md
@@ -1,0 +1,8 @@
+Create a role named `example-dot-com` which allows subdomains.
+
+```shell
+vault write pki_int/roles/example-dot-com \
+  allowed_domains="example.com" \
+  allow_subdomains=true \
+  max_ttl="720h"
+```{{execute}}

--- a/vault-pki-engine/step4.md
+++ b/vault-pki-engine/step4.md
@@ -1,0 +1,9 @@
+Request a new certificate for the `test.example.com` domain based on the
+`example-dot-com` role.
+
+```shell
+vault write pki_int/issue/example-dot-com common_name="test.example.com" ttl="24h"
+```{{execute}}
+
+The response displays the PEM-encoded private key, key type and certificate
+serial number.

--- a/vault-pki-engine/step5.md
+++ b/vault-pki-engine/step5.md
@@ -1,0 +1,21 @@
+Request another certificate and save the serial number a variable named
+`CERT_SERIAL_NUMBER`.
+
+```shell
+CERT_SERIAL_NUMBER=$(vault write -format=json \
+  pki_int/issue/example-dot-com \
+  common_name="test.example.com" \
+  ttl="24h" | jq -r ".data.serial_number")
+```{{execute}}
+
+Display the certificate serial number.
+
+```shell
+echo $CERT_SERIAL_NUMBER
+```{{execute}}
+
+Revoke the certificate with serial number `CERT_SERIAL_NUMBER`.
+
+```shell
+vault write pki_int/revoke serial_number=$CERT_SERIAL_NUMBER
+```{{execute}}

--- a/vault-pki-engine/step6.md
+++ b/vault-pki-engine/step6.md
@@ -1,0 +1,5 @@
+Remove revoked certificate and clean the Certificate Revocation List (CRL).
+
+```shell
+vault write pki_int/tidy tidy_cert_store=true tidy_revoked_certs=true
+```{{execute}}


### PR DESCRIPTION
[Personal Account](https://www.katacoda.com/lynnfrank/scenarios/vault-pki-engine)

Adds the scenario with a focus on the CLI.

This feels like the right pattern. Step 0 focuses on connection and permissions. The remaining steps are light on instructions as its meant to be imbedded.