### PR TITLE
Add HashiCorp packages, Azure command, and Ubuntu 18

### DIFF
--- a/environments/hashistack/Dockerfile
+++ b/environments/hashistack/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN  mkdir -p /stack
 COPY . /stack
@@ -8,14 +8,15 @@ ENV SHELL /bin/bash
 
 RUN apt-get update
 RUN apt-get update 
-RUN apt-get -y  install curl sudo unzip vim
+RUN apt-get -y install curl sudo unzip vim gpg lsb-release
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 
 RUN chmod +x /stack/build/*.sh 
 
 RUN echo "docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-USER docker
+USER root
 RUN /stack/build/*.sh
 
+USER docker
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/environments/hashistack/Makefile
+++ b/environments/hashistack/Makefile
@@ -11,6 +11,7 @@ run: build
 	@echo "==> Running katacoda container..."
 	docker run \
 	  -d \
+	  --cap-add=IPC_LOCK \
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  --name \
 	  $(PROJECT) \

--- a/environments/hashistack/README.md
+++ b/environments/hashistack/README.md
@@ -1,6 +1,6 @@
 # Running Stack in Docker
 
-The Dockerfile will build a ubuntu 16.0.4 image using the build scripts in this directory.
+The Dockerfile will build an Ubuntu image using the build scripts in this directory.
 
 ## Quickstart 
 

--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -1,3 +1,6 @@
+log() {
+  echo $(date) - ${@}
+}
 
 # Download and install a binary.
 #
@@ -5,29 +8,60 @@
 #     - Name of binary ("consul")
 #     - URL of zipfile ("https://example.com/consul.zip")
 #
-install_zip()
+# Usage:
+#   install_from_zip "consul" "https://example.com/consul.zip"
+install_from_zip()
 {
     NAME="$1"
     DOWNLOAD_URL="$2"
 
-    curl -L -o ~/$NAME.zip $DOWNLOAD_URL
-    sudo unzip -d /usr/local/bin/ ~/$NAME.zip
+    mkdir -p /tmp
+
+    curl -L -o /tmp/$NAME.zip $DOWNLOAD_URL
+    sudo unzip -d /usr/local/bin/ /tmp/$NAME.zip
     sudo chmod +x /usr/local/bin/$NAME
-    rm ~/$NAME.zip
+    rm /tmp/$NAME.zip
 }
 
-install_zip "consul" "https://releases.hashicorp.com/consul/1.7.3/consul_1.7.3_linux_amd64.zip"
+install_from_apt() {
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+    set +v
+    CLI_REPO=$(lsb_release -cs)
+    sudo echo "deb [arch=amd64] https://apt.releases.hashicorp.com ${CLI_REPO} main" \
+        > /etc/apt/sources.list.d/hashicorp.list
+    sudo apt-get update
+    sudo apt-get install -y terraform vault consul nomad packer
+}
 
-install_zip "nomad" "https://releases.hashicorp.com/nomad/0.11.2/nomad_0.11.2_linux_amd64.zip"
+install_consul_service_binaries() {
+    # Used by some Consul tutorials
+    curl -sL https://github.com/hashicorp/katakoda/raw/master/consul-connect/assets/bin/counting-service -o /usr/local/bin/counting-service
+    curl -sL https://github.com/hashicorp/katakoda/raw/master/consul-connect/assets/bin/dashboard-service -o /usr/local/bin/dashboard-service
+    chmod +x /usr/local/bin/*-service
+}
 
-install_zip "terraform" "https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip"
+# Create a user account, usually for a service that needs to run
+# a binary as that user, such as consul.
+#
+# Usage:
+#   create_user_account_for "consul"
+create_user_account_for() {
+    NAME="$1"
 
-install_zip "vault" "https://releases.hashicorp.com/vault/1.5.3/vault_1.5.3_linux_amd64.zip"
+    useradd $NAME --create-home
+    mkdir -p /etc/$NAME.d
+    mkdir -p /home/$NAME/log
+    chown -R $NAME /home/$NAME
+}
 
-install_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.25.0/consul-template_0.25.0_linux_amd64.zip"
+install_from_apt
 
-install_zip "envconsul" "https://releases.hashicorp.com/envconsul/0.9.3/envconsul_0.9.3_linux_amd64.zip"
+install_from_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.25.0/consul-template_0.25.0_linux_amd64.zip"
+install_from_zip "envconsul" "https://releases.hashicorp.com/envconsul/0.9.3/envconsul_0.9.3_linux_amd64.zip"
+install_from_zip "sentinel" "https://releases.hashicorp.com/sentinel/0.15.5/sentinel_0.15.5_linux_amd64.zip"
 
-install_zip "sentinel" "https://releases.hashicorp.com/sentinel/0.15.5/sentinel_0.15.5_linux_amd64.zip"
+install_consul_service_binaries
+create_user_account_for "consul"
 
-install_zip "packer" "https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip"
+# Azure CLI
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -30,7 +30,7 @@ install_from_apt() {
     sudo echo "deb [arch=amd64] https://apt.releases.hashicorp.com ${CLI_REPO} main" \
         > /etc/apt/sources.list.d/hashicorp.list
     sudo apt-get update
-    sudo apt-get install -y terraform vault consul nomad packer
+    sudo apt-get install -y terraform=0.13.3 vault=1.5.2 consul=1.8.4 nomad=0.12.4 packer=1.6.2
 }
 
 install_consul_service_binaries() {

--- a/environments/hashistack/katacoda.yaml
+++ b/environments/hashistack/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'ubuntu1604'
+base: 'ubuntu1804'


### PR DESCRIPTION
In order to add the `az` command for interaction with Azure, an upgrade to Ubuntu 18 is needed (for `gpg`).

The official HashiCorp packages are used to install Terraform, Vault, Consul, Nomad, and Packer.