### PR TITLE
[CI/CD] Add POC Inspec Tests for Hashistack Katacoda image

### DIFF
--- a/environments/hashistack/Makefile
+++ b/environments/hashistack/Makefile
@@ -22,6 +22,9 @@ run: build
 clean:
 	@echo "==> Restting kayakoda container..."
 	docker ps | grep $(PROJECT) && docker rm -f $(PROJECT)
+	docker kill $(PROJECT)
+	docker rm -f $(PROJECT)
+
 
 .DEFAULT_GOAL := run 
 

--- a/environments/hashistack/README.md
+++ b/environments/hashistack/README.md
@@ -76,7 +76,7 @@ This will generate an HTML and Command line report on the success and failure.
 You can execute the tests ( which also builds the container ) using:
 
 ```shell
-./inspec.sh
+./spec.sh
 ```
 
 ```

--- a/environments/hashistack/README.md
+++ b/environments/hashistack/README.md
@@ -66,3 +66,46 @@ docker rm -f katacoda
 ```
 
 > All session state will be lost.
+
+# Running Automated tests
+
+The automated tests will run the [inspec](https://www.chef.io/products/chef-inspec) controls against the docker container built by `make`
+
+This will generate an HTML and Command line report on the success and failure.
+
+You can execute the tests ( which also builds the container ) using:
+
+```shell
+./inspec.sh
+```
+
+```
+Profile: tests from ./controls/packer_contol.rb (tests from ..controls.packer_contol.rb)
+Version: (not specified)
+Target:  docker://0540aabbf4d6189a8466e4d40dc4eea125986db07aba06633f8246f9a73cd7ca
+
+  ✔  packer: Packer should be installed
+     ✔  System Package packer is expected to be installed
+
+
+Profile: tests from ./controls/terraform_contol.rb (tests from ..controls.terraform_contol.rb)
+Version: (not specified)
+Target:  docker://0540aabbf4d6189a8466e4d40dc4eea125986db07aba06633f8246f9a73cd7ca
+
+  ✔  terraform: Terraform should be installed
+     ✔  System Package terraform is expected to be installed
+     ✔  File /usr/local/bin/sentinel is expected to be executable
+
+
+Profile: tests from ./controls/vault_control.rb (tests from ..controls.vault_control.rb)
+Version: (not specified)
+Target:  docker://0540aabbf4d6189a8466e4d40dc4eea125986db07aba06633f8246f9a73cd7ca
+
+  ✔  vault: Vault should be installed
+     ✔  System Package vault is expected to be installed
+
+
+Profile Summary: 5 successful controls, 0 control failures, 0 controls skipped
+Test Summary: 12 successful, 0 failures, 0 skipped
+
+```

--- a/environments/hashistack/controls/consul_control.rb
+++ b/environments/hashistack/controls/consul_control.rb
@@ -1,0 +1,30 @@
+control 'Consul' do
+  impact 0.6
+  title 'Consul should be installed'
+  desc 'Consul should be installed and configured'
+  tag 'consul'
+
+  describe package('consul') do
+    it { should be_installed }
+  end
+
+  describe package('azure-cli') do
+    it { should be_installed }
+  end
+
+  describe user('consul') do
+    it { should exist }
+  end
+
+  [
+    'counting-service',
+    'dashboard-service',
+    'consul-template',
+    'envconsul',
+  ].each do |binary|
+    describe file("/usr/local/bin/#{binary}") do
+      it { should be_executable }
+    end
+  end
+
+end

--- a/environments/hashistack/controls/nomad_control.rb
+++ b/environments/hashistack/controls/nomad_control.rb
@@ -1,0 +1,11 @@
+control 'nomad' do
+  impact 0.6
+  title 'Nomad should be installed'
+  desc 'Nomad should be installed and configured'
+  tag 'nomad'
+
+  describe package('nomad') do
+    it { should be_installed }
+  end
+
+end

--- a/environments/hashistack/controls/packer_contol.rb
+++ b/environments/hashistack/controls/packer_contol.rb
@@ -1,0 +1,11 @@
+control 'packer' do
+  impact 0.6
+  title 'Packer should be installed'
+  desc 'Packer should be installed and configured'
+  tag 'packer'
+
+  describe package('packer') do
+    it { should be_installed }
+  end
+
+end

--- a/environments/hashistack/controls/terraform_contol.rb
+++ b/environments/hashistack/controls/terraform_contol.rb
@@ -1,0 +1,20 @@
+control 'terraform' do
+  impact 0.6
+  title 'Terraform should be installed'
+  desc 'Terraform should be installed and configured'
+  tag 'terraform'
+
+  describe package('terraform') do
+    it { should be_installed }
+  end
+
+  # Installed from Zip
+  [
+    'sentinel',
+  ].each do |binary|
+    describe file("/usr/local/bin/#{binary}") do
+      it { should be_executable }
+    end
+  end
+
+end

--- a/environments/hashistack/controls/vault_control.rb
+++ b/environments/hashistack/controls/vault_control.rb
@@ -8,4 +8,9 @@ control 'vault' do
     it { should be_installed }
   end
 
+  # Check for exit for IPC_LOCK in docker requirement
+  describe command('vault -h') do
+    its('exit_status') { should eq 0 }
+  end
+
 end

--- a/environments/hashistack/controls/vault_control.rb
+++ b/environments/hashistack/controls/vault_control.rb
@@ -1,0 +1,11 @@
+control 'vault' do
+  impact 0.6
+  title 'Vault should be installed'
+  desc 'Vault should be installed and configured'
+  tag 'vault'
+
+  describe package('vault') do
+    it { should be_installed }
+  end
+
+end

--- a/environments/hashistack/spec.sh
+++ b/environments/hashistack/spec.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -x
+
+export SCRIPT_DIR="${0%/*}"
+export TARGET="katacoda"
+export HTML_REPORT="/tmp/inspec-$RANDOM$$.html"
+
+cd "$SCRIPT_DIR"
+
+function setup () {
+  # Get execution container
+  docker pull chef/inspec
+
+  # Check if target container is running
+  declare -xi TARGET_RUNNING=$(
+  			docker ps |
+  				grep -c ${TARGET:?})
+
+  # Build container based on current scripts
+  if [[ ${TARGET_RUNNING} == 0 ]] ; then
+    make
+  fi
+}
+
+# Socket allows Docker API targets
+function inspec () {
+   docker run \
+       -it \
+       --rm \
+      --env CHEF_LICENSE='accept-silent' \
+      --volume /var/run/docker.sock:/var/run/docker.sock \
+      --volume "$PWD":/share \
+      --volume /tmp:/tmp \
+      chef/inspec \
+       "$@"
+}
+
+# Setup our dependcies
+setup
+
+# Execute the tests
+inspec exec "${SCRIPT_DIR:?}"/controls/*.rb \
+  --target=docker://${TARGET:?} \
+  --reporter cli html:"${HTML_REPORT:?}" \
+  --log-level=debug \
+  --show-progress
+
+declare -i EXIT_CODE=$?
+
+[ -f "$HTML_REPORT" ] && open "$HTML_REPORT"
+
+# Cleanup
+make clean
+
+exit ${EXIT_CODE:?}

--- a/environments/hashistack/spec.sh
+++ b/environments/hashistack/spec.sh
@@ -34,7 +34,7 @@ function inspec () {
        "$@"
 }
 
-# Setup our dependcies
+# Setup our dependencies
 setup
 
 # Execute the tests


### PR DESCRIPTION

![Screen Shot 2020-09-22 at 12 10 34 PM](https://user-images.githubusercontent.com/1173142/93926759-c6f9a980-fccc-11ea-88b0-f1ed09aa7347.png)


Prior to this commit we did not have "resultant" spec tests for the
current build scripts. This commit adds a testing script that will run
inspec via docker to execute tests against our represetative katacoda
docker image.