### PR TITLE
Replaces the service with a nohup process

### DIFF
--- a/vault-dynamic-secrets/step0.setup.sh
+++ b/vault-dynamic-secrets/step0.setup.sh
@@ -1,5 +1,7 @@
 # Start the Vault server in the background
-/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+mkdir -p ~/log
+nohup sh -c "vault server -dev -dev-root-token-id="root" -dev-listen-address=0.0.0.0:8200 >~/log/vault.log 2>&1" > ~/log/nohup.log &/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+
 
 sleep 5
 

--- a/vault-eaas-transit-rewrap/step0.setup.sh
+++ b/vault-eaas-transit-rewrap/step0.setup.sh
@@ -1,5 +1,7 @@
 # Start the Vault server in the background
-/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+mkdir -p ~/log
+nohup sh -c "vault server -dev -dev-root-token-id="root" -dev-listen-address=0.0.0.0:8200 >~/log/vault.log 2>&1" > ~/log/nohup.log &/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+
 
 sleep 5
 

--- a/vault-openldap/step0.setup.sh
+++ b/vault-openldap/step0.setup.sh
@@ -1,5 +1,7 @@
 # Start the Vault server in the background
-/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+mkdir -p ~/log
+nohup sh -c "vault server -dev -dev-root-token-id="root" -dev-listen-address=0.0.0.0:8200 >~/log/vault.log 2>&1" > ~/log/nohup.log &/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+
 
 sleep 5
 

--- a/vault-pki-engine/step0.setup.sh
+++ b/vault-pki-engine/step0.setup.sh
@@ -1,5 +1,6 @@
 # Start the Vault server in the background
-/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+mkdir -p ~/log
+nohup sh -c "vault server -dev -dev-root-token-id="root" -dev-listen-address=0.0.0.0:8200 >~/log/vault.log 2>&1" > ~/log/nohup.log &/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
 
 sleep 5
 


### PR DESCRIPTION
Without the `nohup` the process is being terminated by Katacoda when the practitioner transitions to the next step.