### PR TITLE
[Vault] Remove note about shortcut

### DIFF
--- a/vault-GS-first-secrets/step1.md
+++ b/vault-GS-first-secrets/step1.md
@@ -2,8 +2,6 @@ Now that the dev server is up and running, let's get straight to it and read and
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-GS-policy/step1.md
+++ b/vault-GS-policy/step1.md
@@ -1,7 +1,5 @@
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-agent-templates/step1.md
+++ b/vault-agent-templates/step1.md
@@ -1,7 +1,5 @@
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-agent/step1.md
+++ b/vault-agent/step1.md
@@ -6,8 +6,6 @@ For this scenario, you are going to run the Vault Agent on the same machine as w
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-approle/step1.md
+++ b/vault-approle/step1.md
@@ -1,7 +1,5 @@
 Before begin, login with Vault using a root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-auth/step1.md
+++ b/vault-auth/step1.md
@@ -2,8 +2,6 @@ The username/password combinations are configured directly to the auth method us
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-batch-tokens/step1.md
+++ b/vault-batch-tokens/step1.md
@@ -21,8 +21,6 @@ following table highlights the difference.
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-cubbyhole/step1.md
+++ b/vault-cubbyhole/step1.md
@@ -1,7 +1,5 @@
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-ent-playground/step1.md
+++ b/vault-ent-playground/step1.md
@@ -1,7 +1,5 @@
 Enter the following command to see the Vault server status.  
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault status
 ```{{execute T1}}

--- a/vault-identity/step1.md
+++ b/vault-identity/step1.md
@@ -10,8 +10,6 @@ A user, Bob Smith at ACME Inc. happened to have two sets of credentials: `bob` a
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-playground-2/getting-started.md
+++ b/vault-playground-2/getting-started.md
@@ -1,7 +1,5 @@
 Enter the following command to see the Vault server status.  
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault status
 ```{{execute T1}}
@@ -20,7 +18,7 @@ Click on the **Vault UI** tab to launch the Vault UI.
 
 ![](./assets/katacoda-vault-ui.png)
 
-Enter **`root`** in the **Token** text field and then click **Sign In**. 
+Enter **`root`** in the **Token** text field and then click **Sign In**.
 
 <br>
 

--- a/vault-playground/getting-started.md
+++ b/vault-playground/getting-started.md
@@ -1,7 +1,5 @@
 Enter the following command to see the Vault server status.  
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault status
 ```{{execute T1}}
@@ -20,7 +18,7 @@ Click on the **Vault UI** tab to launch the Vault UI.
 
 ![](./assets/katacoda-vault-ui.png)
 
-Enter **`root`** in the **Token** text field and then click **Sign In**. 
+Enter **`root`** in the **Token** text field and then click **Sign In**.
 
 <br>
 

--- a/vault-policies/step1.md
+++ b/vault-policies/step1.md
@@ -2,8 +2,6 @@
 
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-policy-templating/getting-started.md
+++ b/vault-policy-templating/getting-started.md
@@ -1,8 +1,5 @@
 Enter the following command to start the Vault server in development mode.  
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
-
 ```
 vault server -dev -dev-root-token-id="root"
 ```{{execute T1}}

--- a/vault-policy-templating/step1.md
+++ b/vault-policy-templating/step1.md
@@ -63,8 +63,6 @@ This policy fulfills the policy requirement 2 and 3.
 
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-raft-ha/step1.md
+++ b/vault-raft-ha/step1.md
@@ -13,8 +13,6 @@ You have a Vault server which uses filesystem as its storage backend. Since file
 
 ### Start Vault Server 1 (node1)
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 `clear`{{execute T1}}
 
 First review the server configuration file, `config-node1.hcl`{{open}}.

--- a/vault-raft/step1.md
+++ b/vault-raft/step1.md
@@ -37,8 +37,6 @@ The `storage` stanza is set to use `raft` which is the integrated storage. The `
 
 Enter the following command to start the `node1` Vault server.  
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 mkdir raft-node1
 vault server -config=config-node1.hcl

--- a/vault-resource-quotas/step1.md
+++ b/vault-resource-quotas/step1.md
@@ -7,8 +7,6 @@
 
 Let's begin!  First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-static-secrets/step1.md
+++ b/vault-static-secrets/step1.md
@@ -1,7 +1,5 @@
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-telemetry-splunk/01-start-containers.md
+++ b/vault-telemetry-splunk/01-start-containers.md
@@ -1,5 +1,16 @@
 > Click the command (`⮐`) to automatically copy it into the terminal and execute it.
 
+Before start, verify that `main.tf` file exists.
+
+```
+ls -al | grep main.tf
+```{{execute T1}}
+
+<div style="background-color:#fbe5e5; color:#864242; border:1px solid #f8cfcf; padding:1em; border-radius:3px; margin:24px 0;">
+<p>
+If `main.tf` does not exist, wait for additional 5~10 seconds and try again. Once the file is copied over, you are ready to start!
+</p></div>
+
 The first step in this lab is to use Terraform to start the containers.
 
 You will do this with 3 `terraform` commands, which accomplish the following tasks:

--- a/vault-terraform-ent/step1.md
+++ b/vault-terraform-ent/step1.md
@@ -35,8 +35,6 @@ Following Terraform files are provided:
 
 ## Run Terraform
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 Set the `VAULT_ADDR` environment variable with value.
 
 ```

--- a/vault-terraform-oss/step1.md
+++ b/vault-terraform-oss/step1.md
@@ -33,8 +33,6 @@ Following Terraform files are provided:
 
 ## Run Terraform commands
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 Set the `VAULT_TOKEN` environment variable with value, `root`.
 
 ```

--- a/vault-tokens/step1.md
+++ b/vault-tokens/step1.md
@@ -1,7 +1,5 @@
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}
@@ -47,7 +45,7 @@ vault login $(cat ttl_token.txt)
 
 The output displays the **`token_duration`** left with this token in seconds.
 
-> Notice that the policy attached to this token is `root`. When you create a new token without specifying which policies to attach, the created token inherits the policies attached to its parent (the token used to create the new token which is `root` in this case). 
+> Notice that the policy attached to this token is `root`. When you create a new token without specifying which policies to attach, the created token inherits the policies attached to its parent (the token used to create the new token which is `root` in this case).
 
 Wait for a few seconds to let the TTL to be reached, and re-run the login command:
 

--- a/vault-tools/step1.md
+++ b/vault-tools/step1.md
@@ -1,7 +1,5 @@
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-transform-hashiconf/step1.md
+++ b/vault-transform-hashiconf/step1.md
@@ -1,7 +1,5 @@
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-transform/step1.md
+++ b/vault-transform/step1.md
@@ -5,8 +5,6 @@
 
 First, login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}

--- a/vault-transit/step1.md
+++ b/vault-transit/step1.md
@@ -1,7 +1,5 @@
 Login with root token.
 
-> Click on the command (`⮐`) will automatically copy it into the terminal and execute it.
-
 ```
 vault login root
 ```{{execute T1}}


### PR DESCRIPTION
Remove "Click on the command (`⮐`) will automatically copy it into the terminal and execute it" from all scenario to encourage the students to type in the commands. 