### PR TITLE
Update to use kv-v2 instead of kv-v1

### DIFF
--- a/consul-secure-gossip-vault/assets/gossip.key.tpl
+++ b/consul-secure-gossip-vault/assets/gossip.key.tpl
@@ -1,3 +1,3 @@
-{{ with secret "kv-v1/consul/config/encryption" }}
-{{ .Data.key}}
+{{ with secret "kv-v2/data/consul/config/encryption" }}
+{{ .Data.data.key}}
 {{ end }}

--- a/consul-secure-gossip-vault/step0.md
+++ b/consul-secure-gossip-vault/step0.md
@@ -3,13 +3,15 @@ First, create a directory to store the logging output of the Vault server.
 
 `mkdir -p /opt/vault/logs`{{execute T1}}
 
-Next, start the Vault server. 
+Next, start the Vault server.
 
 `nohup sh -c "vault server -dev -dev-root-token-id="root" -dev-listen-address=0.0.0.0:8200 >/opt/vault/logs/vault.log 2>&1" > /opt/vault/logs/nohup.log &`{{execute T1}}
 
-Finally, to communicate with the Vault server you will need to set the address and token. 
+Set `VAULT_ADDR` environment variable to the Vault server address to connect.
 
 `export VAULT_ADDR='http://127.0.0.1:8200'`{{execute T1}}
+
+Create a `VAULT_TOKEN` environment variable to store the client token (`root`).
 
 `export VAULT_TOKEN="root"`{{execute T1}}
 

--- a/consul-secure-gossip-vault/step1.md
+++ b/consul-secure-gossip-vault/step1.md
@@ -1,13 +1,13 @@
 For this lab, you will use the Vault KV secrets engine.
 
-First, enable a new secret engine called `kv` at path `kv-v1`
+First, enable key/value v2 secrets engine (`kv-v2`).
 
-`vault secrets enable -path="kv-v1" kv`{{execute}}
+`vault secrets enable kv-v2`{{execute}}
 
 Example output:
 
 ```
-Success! Enabled the kv secrets engine at: kv-v1/
+Success! Enabled the kv-v2 secrets engine at: kv-v2/
 ```
 
 Once the secret engine is enabled, verify it this using
@@ -21,7 +21,7 @@ Example output:
 Path          Type         Accessor              Description
 ----          ----         --------              -----------
 ...
-kv-v1/        kv           kv_5e0867f7           n/a
+kv-v2/        kv           kv_5e0867f7           n/a
 secret/       kv           kv_b5027aee           key/value secret storage
 ...
 ```
@@ -67,16 +67,21 @@ enter it into Consul's configuration file later.
 
 ### Write encryption key in Vault
 
-`vault kv put kv-v1/consul/config/encryption key=${CONSUL_GOSSIP_KEY} ttl=10s`{{execute}}
+`vault kv put kv-v2/consul/config/encryption key=${CONSUL_GOSSIP_KEY} ttl=10s`{{execute}}
 
 Example output:
+
 ```
-Success! Data written to: kv-v1/consul/config/encryption
+Key              Value
+---              -----
+created_time     2020-11-06T02:04:12.065476985Z
+deletion_time    n/adestroyed        false
+version          1
 ```
 
 <div style="background-color:#eff5ff; color:#416f8c; border:1px solid #d0e0ff; padding:1em; border-radius:3px; margin:24px 0;">
   <p><strong>Info:</strong><br>
-  
+
   Unlike other secrets engines, the KV secrets engine does not enforce TTLs for expiration. Instead, the `lease_duration` is a hint for how often consumers should check back for a new value.
 
   Yuu can change the `ttl` value or not use it in your case but you will need a TTL to integrate with `consul-template` and have it automatically check for new versions of the key.

--- a/consul-secure-gossip-vault/step2.md
+++ b/consul-secure-gossip-vault/step2.md
@@ -5,7 +5,7 @@ From your Consul server node, use the `vault kv get`
 command using the `-field` parameter to retrieve the
 key value only.
 
-`vault kv get -field=key kv-v1/consul/config/encryption | tee encryption.key`{{execute}}
+`vault kv get -field=key kv-v2/consul/config/encryption | tee encryption.key`{{execute}}
 
 <div style="background-color:#fcf6ea; color:#866d42; border:1px solid #f8ebcf; padding:1em; border-radius:3px;">
   <p><strong>Warning: </strong>

--- a/consul-secure-gossip-vault/step4.md
+++ b/consul-secure-gossip-vault/step4.md
@@ -44,11 +44,11 @@ consul-template will automatically update the file every time the key is updated
 
 You can test this by generating a new key:
 
-`vault kv put kv-v1/consul/config/encryption key=$(consul keygen) ttl=1s`{{execute T1}}
+`vault kv put kv-v2/consul/config/encryption key=$(consul keygen) ttl=1s`{{execute T1}}
 
 Example output:
 ```
-Success! Data written to: kv-v1/consul/config/encryption
+Success! Data written to: kv-v2/consul/config/encryption
 ```
 
 This will update the file:

--- a/consul-secure-gossip-vault/step5.md
+++ b/consul-secure-gossip-vault/step5.md
@@ -65,7 +65,7 @@ Now you can restart it using the new configuration file `consul_template_autorot
 
 Now every time you update the key value in Vault, `consul-template` will make sure that the key is installed in Consul too.
 
-`vault kv put kv-v1/consul/config/encryption key=$(consul keygen) ttl=1s`{{execute T1}}
+`vault kv put kv-v2/consul/config/encryption key=$(consul keygen) ttl=1s`{{execute T1}}
 
 The script will pick up the `gossip.key` file containing the new key and use it to rotate the Consul gossip encryption key.
 


### PR DESCRIPTION
This is for the [PR 2508](https://github.com/hashicorp/learn/pull/2508).

I'm so sorry that I completely forgot to do this after the HashiConf.  I know people asked why using `kv-v1` instead of `kv-v2` and this should make them happy now. 