### PR TITLE
Terraform scenario upgrades for 0.14, small improvements

### DIFF
--- a/terraform-build-modules/courseBase.sh
+++ b/terraform-build-modules/courseBase.sh
@@ -4,9 +4,6 @@
 curl -O https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_linux_amd64.zip
 unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 
-# Installs awscli
-apt-get install awscli -y
-
 # Clone GitHub repo
 git clone -b localstack https://github.com/ritsok/learn-terraform-modules
 cd ~/learn-terraform-modules
@@ -15,7 +12,7 @@ cd ~/learn-terraform-modules
 # docker-compose up -d
 
 # Install localstack (don't run dockerfile on katacoda)
-pip3 install localstack
+pip3 install localstack awscli
 localstack start &>localstack-output.log &
 
 # Prevent `yes` command from accidentally being run

--- a/terraform-build-modules/courseBase.sh
+++ b/terraform-build-modules/courseBase.sh
@@ -1,8 +1,8 @@
 # Install Terraform and init config
 
-# Installs Terraform 0.13.5
-curl -O https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
-unzip terraform_0.13.5_linux_amd64.zip -d /usr/local/bin/
+# Installs Terraform 0.14.6
+curl -O https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_linux_amd64.zip
+unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 
 # Installs awscli
 apt-get install awscli -y

--- a/terraform-build-modules/courseBase.sh
+++ b/terraform-build-modules/courseBase.sh
@@ -8,7 +8,7 @@ unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 apt-get install awscli -y
 
 # Clone GitHub repo
-git clone -b localstack https://github.com/hashicorp/learn-terraform-modules
+git clone -b localstack https://github.com/ritsok/learn-terraform-modules
 cd ~/learn-terraform-modules
 
 # Run Docker Compose up (daemon)

--- a/terraform-build-modules/courseBase.sh
+++ b/terraform-build-modules/courseBase.sh
@@ -5,7 +5,7 @@ curl -O https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_linux_a
 unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 
 # Clone GitHub repo
-git clone -b localstack https://github.com/ritsok/learn-terraform-modules
+git clone -b localstack https://github.com/hashicorp/learn-terraform-modules
 cd ~/learn-terraform-modules
 
 # Run Docker Compose up (daemon)

--- a/terraform-build-modules/index.json
+++ b/terraform-build-modules/index.json
@@ -41,5 +41,5 @@
   "backend": {
     "imageid": "ubuntu"
   },
-  "private": true
+  "private": false
 }

--- a/terraform-build-modules/index.json
+++ b/terraform-build-modules/index.json
@@ -40,7 +40,7 @@
     "hideHiddenFiles": true
   },
   "backend": {
-    "imageid": "ubuntu"
+    "imageid": "ubuntu:2004"
   },
-  "private": false
+  "private": true
 }

--- a/terraform-build-modules/index.json
+++ b/terraform-build-modules/index.json
@@ -33,7 +33,7 @@
     }
   },
   "environment": {
-    "terminals": [{"name": "Terminal 1", "target": "host01"}, {"name": "Terminal 2", "command": "export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test", "target": "host01"}],
+    "terminals": [{"name": "Terminal 2", "target": "host01"}],
     "uilayout": "editor-terminal",
     "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n",
     "uieditorpath": "/root/learn-terraform-modules",

--- a/terraform-build-modules/index.json
+++ b/terraform-build-modules/index.json
@@ -33,6 +33,7 @@
     }
   },
   "environment": {
+    "terminals": [{"name": "Terminal 1", "target": "host01"}, {"name": "Terminal 2", "command": "export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test", "target": "host01"}],
     "uilayout": "editor-terminal",
     "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n",
     "uieditorpath": "/root/learn-terraform-modules",

--- a/terraform-build-modules/step1.md
+++ b/terraform-build-modules/step1.md
@@ -1,5 +1,8 @@
 Be sure to work in Terminal 2 for this scenario for the smoothest experience.
 
+Change into the sample code directory.
+
+`cd ~/learn-terraform-modules`{{execute T2}}
 
 Open `main.tf`{{open}}. 
 

--- a/terraform-build-modules/step1.md
+++ b/terraform-build-modules/step1.md
@@ -1,7 +1,7 @@
 Be sure to work in Terminal 2 for this scenario for the smoothest experience.
 
 
-Open `main.tf`{{open T2}}. 
+Open `main.tf`{{open}}. 
 
 This configuration includes three blocks:
 

--- a/terraform-build-modules/step1.md
+++ b/terraform-build-modules/step1.md
@@ -1,3 +1,11 @@
+/* This tutorial works best when run in a new tab in this Katacoda scenario.  */
+/*  */
+/* Open a new tab */
+/*  */
+/* Export the test AWS credentials as environment variables. */
+/*  */
+/* `export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test`{{execute}} */
+
 Open `main.tf`{{open}}. 
 
 This configuration includes three blocks:

--- a/terraform-build-modules/step1.md
+++ b/terraform-build-modules/step1.md
@@ -1,12 +1,7 @@
-/* This tutorial works best when run in a new tab in this Katacoda scenario.  */
-/*  */
-/* Open a new tab */
-/*  */
-/* Export the test AWS credentials as environment variables. */
-/*  */
-/* `export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test`{{execute}} */
+Be sure to work in Terminal 2 for this scenario for the smoothest experience.
 
-Open `main.tf`{{open}}. 
+
+Open `main.tf`{{open T2}}. 
 
 This configuration includes three blocks:
 

--- a/terraform-build-modules/step2.md
+++ b/terraform-build-modules/step2.md
@@ -44,7 +44,6 @@ Create another file called LICENSE.
 
 `touch modules/aws-s3-static-website-bucket/LICENSE`{{execute T2}}
 
-
 Open `modules/aws-s3-static-website-bucket/LICENSE`{{open}} and paste in
 the contents below.
 
@@ -68,7 +67,7 @@ Create the `main.tf` configuration file for the module.
 
 `touch modules/aws-s3-static-website-bucket/main.tf`{{execute T2}}
 
-Add the following to `modules/aws-s3-static-website-bucket/LICENSE`{{open}}. This configuration creates a public S3 bucket hosting a website with an index page and an error page.
+Add the following to `modules/aws-s3-static-website-bucket/main.tf`{{open}}. This configuration creates a public S3 bucket hosting a website with an index page and an error page.
 
 <pre class="file" data-target="clipboard">
 resource "aws_s3_bucket" "s3_bucket" {

--- a/terraform-build-modules/step2.md
+++ b/terraform-build-modules/step2.md
@@ -13,6 +13,9 @@ should look like the following.
 ├── main.tf
 ├── modules
 │   └── aws-s3-static-website-bucket
+├── assets
+│   └── index.html
+│   └── error.html
 ├── outputs.tf
 └── variables.tf
 ```

--- a/terraform-build-modules/step2.md
+++ b/terraform-build-modules/step2.md
@@ -28,6 +28,9 @@ Inside the `aws-s3-static-website-bucket` directory, create a file called
 
 `touch modules/aws-s3-static-website-bucket/README.md`{{execute}}
 
+Open `modules/aws-s3-static-website-bucket/README.md`{{open}} and paste in
+the contents below.
+
 <pre class="file" data-target="clipboard">
 # AWS S3 static website bucket
 
@@ -37,9 +40,12 @@ This module provisions AWS S3 buckets configured for static website hosting.
 Choosing the correct license for your modules is out of the scope of this 
 tutorial. This tutorial will use the Apache 2.0 open source license.
 
-Create another file called LICENSE with the following content.
+Create another file called LICENSE.
 
 `touch modules/aws-s3-static-website-bucket/LICENSE`{{execute}}
+
+Open `modules/aws-s3-static-website-bucket/LICENSE`{{open}} and paste in
+the contents below.
 
 <pre class="file" data-target="clipboard">
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,9 +63,11 @@ limitations under the License.
 
 ## Add module configuration
 
-Add the following to the `main.tf` inside the `modules/aws-s3-static-website-bucket` directory. This configuration creates a public S3 bucket hosting a website with an index page and an error page.
+Create the `main.tf` configuration file for the module. 
 
 `touch modules/aws-s3-static-website-bucket/main.tf`{{execute}}
+
+Add the following to `modules/aws-s3-static-website-bucket/LICENSE`{{open}}. This configuration creates a public S3 bucket hosting a website with an index page and an error page.
 
 <pre class="file" data-target="clipboard">
 resource "aws_s3_bucket" "s3_bucket" {
@@ -104,10 +112,12 @@ variables.
 
 ### Create variables file
 
-Define the following variables in the `variables.tf` file inside the
-`modules/aws-s3-static-website-bucket` directory.
+Next, create the `variables.tf` file.
 
 `touch modules/aws-s3-static-website-bucket/variables.tf`{{execute}}
+
+Define the following variables in the
+`modules/aws-s3-static-website-bucket/variables.tf`{{open}} file.
 
 <pre class="file" data-target="clipboard">
 variable "bucket_name" {
@@ -147,7 +157,12 @@ the module.
 Add outputs to your module in the `outputs.tf` file inside the
 `modules/aws-s3-static-website-bucket` directory.
 
+Now, create the `outputs.tf` file.
+
 `touch modules/aws-s3-static-website-bucket/outputs.tf`{{execute}}
+
+Add outputs to your module in
+`modules/aws-s3-static-website-bucket/outputs.tf`{{open}} file.  
 
 <pre class="file" data-target="clipboard">
 # Output variable definitions

--- a/terraform-build-modules/step2.md
+++ b/terraform-build-modules/step2.md
@@ -1,7 +1,7 @@
 Create a directory named `modules`, with a directory called 
 `aws-s3-static-website-bucket` inside of it.
 
-`mkdir -p modules/aws-s3-static-website-bucket`{{execute}}
+`mkdir -p modules/aws-s3-static-website-bucket`{{execute T2}}
 
 After creating these directories, your configuration's directory structure 
 should look like the following.
@@ -26,7 +26,7 @@ shared with others.
 Inside the `aws-s3-static-website-bucket` directory, create a file called
 `README.md` with the following content.
 
-`touch modules/aws-s3-static-website-bucket/README.md`{{execute}}
+`touch modules/aws-s3-static-website-bucket/README.md`{{execute T2}}
 
 Open `modules/aws-s3-static-website-bucket/README.md`{{open}} and paste in
 the contents below.
@@ -42,7 +42,8 @@ tutorial. This tutorial will use the Apache 2.0 open source license.
 
 Create another file called LICENSE.
 
-`touch modules/aws-s3-static-website-bucket/LICENSE`{{execute}}
+`touch modules/aws-s3-static-website-bucket/LICENSE`{{execute T2}}
+
 
 Open `modules/aws-s3-static-website-bucket/LICENSE`{{open}} and paste in
 the contents below.
@@ -65,7 +66,7 @@ limitations under the License.
 
 Create the `main.tf` configuration file for the module. 
 
-`touch modules/aws-s3-static-website-bucket/main.tf`{{execute}}
+`touch modules/aws-s3-static-website-bucket/main.tf`{{execute T2}}
 
 Add the following to `modules/aws-s3-static-website-bucket/LICENSE`{{open}}. This configuration creates a public S3 bucket hosting a website with an index page and an error page.
 
@@ -114,7 +115,7 @@ variables.
 
 Next, create the `variables.tf` file.
 
-`touch modules/aws-s3-static-website-bucket/variables.tf`{{execute}}
+`touch modules/aws-s3-static-website-bucket/variables.tf`{{execute T2}}
 
 Define the following variables in the
 `modules/aws-s3-static-website-bucket/variables.tf`{{open}} file.
@@ -159,7 +160,7 @@ Add outputs to your module in the `outputs.tf` file inside the
 
 Now, create the `outputs.tf` file.
 
-`touch modules/aws-s3-static-website-bucket/outputs.tf`{{execute}}
+`touch modules/aws-s3-static-website-bucket/outputs.tf`{{execute T2}}
 
 Add outputs to your module in
 `modules/aws-s3-static-website-bucket/outputs.tf`{{open}} file.  

--- a/terraform-build-modules/step2.md
+++ b/terraform-build-modules/step2.md
@@ -14,8 +14,6 @@ should look like the following.
 ├── modules
 │   └── aws-s3-static-website-bucket
 ├── outputs.tf
-├── terraform.tfstate
-├── terraform.tfstate.backup
 └── variables.tf
 ```
 

--- a/terraform-build-modules/step3.md
+++ b/terraform-build-modules/step3.md
@@ -42,11 +42,6 @@ output "website_bucket_name" {
   value       = module.website_s3_bucket.name
 }
 
-output "website_bucket_domain" {
-  description = "Domain name of the bucket"
-  value       = module.website_s3_bucket.domain
-}
-
 output "localstack_bucket_index_file" {
   description = "Location of index file in localstack bucket"
   value       = "${module.website_s3_bucket.name}.localhost:4566/${module.website_s3_bucket.name}/index.html"

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -24,10 +24,6 @@ bucket, so there would be nothing to return if you were to visit the bucket's we
 In order the bucket website to return any content, you will need to upload 
 objects to your bucket. 
 
-First, export the test AWS credentials as environment variables.
-
-`export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test`{{execute}}
-
 The static website files are located in the `/assets/` directory. Upload these
 files to the S3 bucket using the [AWS CLI tool](https://aws.amazon.com/cli/).
 
@@ -42,6 +38,6 @@ Verify that the file was uploaded successfully. Because this scenario uses
 localstack, the S3 bucket is hosted locally.
 
 Visit the website endpoint below in a web browser. You should find the website
-contents, which will be a page that says "Nothing to see here".
+contents.
 
-`2886795304-4566-kitek05.environments.katacoda.com/terraform-edu-module/index.html`
+`[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-module/index.html`

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -4,7 +4,7 @@ module before it can be used. Both the `terraform get` and `terraform init`
 commands will install and update modules. The `terraform init` command will also
 initialize backends and install providers.
 
-Now install the module by running `terraform init`{{execute}}.
+Now install the module by running `terraform init`{{execute T2}}.
 
 -> **Note**: When installing a remote module, Terraform will download it into
 the `.terraform` directory in your configuration's root directory. When
@@ -12,8 +12,8 @@ installing a local module, Terraform will instead refer directly to the source
 directory. Because of this, Terraform will automatically notice changes to
 local modules without having to re-run `terraform init` or `terraform get`.
 
-Now that your new module is installed and configured, run `terraform apply`{{execute}} to
-provision your bucket. After you respond to the prompt with `yes`{{execute}}, 
+Now that your new module is installed and configured, run `terraform apply`{{execute T2}} to
+provision your bucket. After you respond to the prompt with `yes`{{execute T2}}, 
 your bucket and other resources will be provisioned.
 
 ## Upload files to the bucket
@@ -21,13 +21,18 @@ your bucket and other resources will be provisioned.
 You have now configured and used your own module to create a static website. You
 may want to visit this static website. Right now there is nothing inside your
 bucket, so there would be nothing to return if you were to visit the bucket's website. 
+
 In order the bucket website to return any content, you will need to upload 
 objects to your bucket. 
+
+First, export the AWS credentials used for localstack:
+
+`export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test`{{execute T2}}
 
 The static website files are located in the `/assets/` directory. Upload these
 files to the S3 bucket using the [AWS CLI tool](https://aws.amazon.com/cli/).
 
-`aws --endpoint-url=http://localhost:4566 s3 cp assets/ s3://$(terraform output -raw website_bucket_name)/ --recursive`{{execute}}
+`aws --endpoint-url=http://localhost:4566 s3 cp assets/ s3://$(terraform output -raw website_bucket_name)/ --recursive`{{execute T2}}
 
 Note the usage of the `--endpoint-url` parameter -- this configures the AWS CLI
 to use the localstack instance of AWS. 
@@ -40,4 +45,4 @@ localstack, the S3 bucket is hosted locally.
 Visit the website endpoint below in a web browser. You should find the website
 contents.
 
-`[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-module/index.html`
+`[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-modules/index.html`

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -39,10 +39,8 @@ to use the localstack instance of AWS.
 
 ## Verify website endpoint
 
-Verify that the file was uploaded successfully. Because this scenario uses
+Visit [this
+endpoint](https://[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-modules/index.html)
+to verify that the files were uploaded successfully. Because this scenario uses
 localstack, the S3 bucket is hosted locally.
 
-Visit the website endpoint below in a web browser. You should find the website
-contents.
-
-[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-modules/index.html

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -27,18 +27,17 @@ objects to your bucket.
 The static website files are located in the `/assets/` directory. Upload these
 files to the S3 bucket using the [AWS CLI tool](https://aws.amazon.com/cli/).
 
-`aws s3 cp assets/ s3://$(terraform output website_bucket_name)/ --recursive`{{execute}}
+`aws --endpoint-url=http://localhost:4566 s3 cp assets/ s3://$(terraform output -raw website_bucket_name)/ --recursive`{{execute}}
+
+Note the usage of the `--endpoint-url` parameter -- this configures the AWS CLI
+to use the localstack instance of AWS. 
 
 ## Verify website endpoint
 
 Verify that the file was uploaded successfully. Because this scenario uses
 localstack, the S3 bucket is hosted locally.
 
-Get the bucket name.
+Visit the website endpoint below in a web browser. You should find the website
+contents, which will be a page that says "Nothing to see here".
 
-`terraform output website_bucket_name`{{execute}}
-
-Then, visit the website endpoint in a web browser, replacing `<BUCKET_NAME>` 
-with your bucket name. You should find the website contents.
-
-`[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/${module.website_s3_bucket.name}/index.html`
+`2886795304-4566-kitek05.environments.katacoda.com/terraform-edu-module/index.html`

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -24,6 +24,10 @@ bucket, so there would be nothing to return if you were to visit the bucket's we
 In order the bucket website to return any content, you will need to upload 
 objects to your bucket. 
 
+First, export the test AWS credentials as environment variables.
+
+`export AWS_ACCESS_KEY_ID=test && AWS_SECRET_ACCESS_KEY=test`{{execute}}
+
 The static website files are located in the `/assets/` directory. Upload these
 files to the S3 bucket using the [AWS CLI tool](https://aws.amazon.com/cli/).
 

--- a/terraform-build-modules/step4.md
+++ b/terraform-build-modules/step4.md
@@ -6,7 +6,7 @@ initialize backends and install providers.
 
 Now install the module by running `terraform init`{{execute T2}}.
 
--> **Note**: When installing a remote module, Terraform will download it into
+> **Note**: When installing a remote module, Terraform will download it into
 the `.terraform` directory in your configuration's root directory. When
 installing a local module, Terraform will instead refer directly to the source
 directory. Because of this, Terraform will automatically notice changes to
@@ -45,4 +45,4 @@ localstack, the S3 bucket is hosted locally.
 Visit the website endpoint below in a web browser. You should find the website
 contents.
 
-`[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-modules/index.html`
+[[HOST_SUBDOMAIN]]-4566-[[KATACODA_HOST]].environments.katacoda.com/terraform-edu-modules/index.html

--- a/terraform-consul-provider/courseBase.sh
+++ b/terraform-consul-provider/courseBase.sh
@@ -5,8 +5,8 @@ apt-get install -y docker-ce docker-ce-cli containerd.io unzip < "/dev/null"
 # Install unzip - Katacoda docker image doesn't have unzip
 # apt-get install unzip
 cd ..
-curl -O https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip
-unzip terraform_0.12.20_linux_amd64.zip -d /usr/local/bin/
+curl -O https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_linux_amd64.zip
+unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 
 # Clone docker compose files
 git clone https://github.com/hashicorp/getting-started-terraform-consul-provider

--- a/terraform-organize-configuration/courseBase.sh
+++ b/terraform-organize-configuration/courseBase.sh
@@ -1,8 +1,8 @@
 # Install Terraform and init config
 
-# Installs Terraform 0.13.5
-curl -O https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
-unzip terraform_0.13.5_linux_amd64.zip -d /usr/local/bin/
+# Installs Terraform 0.14.6
+curl -O https://releases.hashicorp.com/terraform/0.14.6/terraform_0.14.6_linux_amd64.zip
+unzip terraform_0.14.6_linux_amd64.zip -d /usr/local/bin/
 
 # Installs awscli
 apt-get install awscli -y

--- a/terraform-organize-configuration/step1.md
+++ b/terraform-organize-configuration/step1.md
@@ -8,34 +8,39 @@ below.
 
 ```
 provider "aws" {
-  region = var.aws_region
+  region = "us-west-2"
   # ...
 }
 ```
 
-It also includes additional settings that allow this scenario to use 
-[localstack](https://localstack.cloud/) to simulate infrastructure, instead of 
-requiring you to have an AWS account. Refer to the code in the 
-[Learn tutorial](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules) 
+It also includes settings that allow this scenario to use
+[localstack](https://localstack.cloud/) to simulate infrastructure, instead of
+requiring an AWS account. Refer to the code in the [Learn
+tutorial](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules)
 to build real infrastructure, which will require you to authenticate with AWS. 
 
-Refer to the [AWS Get Started collection](https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started)
-or the [AWS Provider Registry page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication)
+Refer to the [AWS Get Started
+collection](https://learn.hashicorp.com/tutorials/terraform/aws-build?in=terraform/aws-get-started)
+or the [AWS Provider Registry
+page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication)
 to learn different ways to authenticate the AWS provider.
 
 ## Review monolithic configuration
 
-Now that you have configured the AWS provider, review the rest of the
-configuration found in `main.tf`{{open}}. This configuration will create two S3
+Now that you have reviewed the AWS provider configuration, review the rest of the
+configuration found in `main.tf`{{open}}. This configuration creates two S3
 buckets, each configured to host a static website, and each containing a single
 `index.html`. One bucket will be for your `dev` environment, and the other for
 `prod`.
 
-Notice the three variables used in your configuration. Open `variables.tf`{{open}} and notice how these variables are declared with default values.
+Notice the three variables used in your configuration. Open
+`variables.tf`{{open}} and note how these variables are declared with default
+values.
 
-Now open `outputs.tf`{{open}}, which will output the website endpoints for the two
-buckets once Terraform creates them. Later you will use these values to visit the website and verify that your
-configuration was successfully deployed.
+Now open `outputs.tf`{{open}}, which will defines outputs for the website
+endpoints for the two buckets once Terraform creates them. Later you will use
+these values to visit the website and verify that your configuration was
+successfully deployed.
 
 ## Apply configuration
 

--- a/terraform-organize-configuration/step2.md
+++ b/terraform-organize-configuration/step2.md
@@ -1,6 +1,5 @@
-Now that you have a monolithic configuration to work with, in this step you will
-separate the configuration into two files, one for your "dev" environment, and
-one for "prod".
+In this step you will separate the monolithic Terraform configuration into two
+files, one for your "dev" environment, and one for "prod".
 
 ## Separate configuration files
 
@@ -16,12 +15,13 @@ Next, rename `main.tf` to `prod.tf`.
 mv main.tf prod.tf
 ```{{execute}}
 
-Your configuration only needs one instance of the provider and random_pet
+Your configuration only needs one instance of the AWS provider and random_pet
 blocks, so remove these lines from `prod.tf`{{open}}.
 
 ```
 provider "aws" {
-  region = var.aws_region
+  region = "us-west-2"
+  # ...
 }
 
 resource "random_pet" "petname" {
@@ -30,7 +30,7 @@ resource "random_pet" "petname" {
 }
 ```
 
-Also remove the resource blocks for your `dev` environment from `prod.tf`{{open}}.
+Remove the resource blocks for your `dev` environment from `prod.tf`{{open}} as well.
 
 First, remove the bucket resource.
 
@@ -59,10 +59,10 @@ resource "aws_s3_bucket_object" "dev" {
 }
 ```
 
-Once this is done, you will have two resource blocks in `prod.tf`: One for the
+You should now have two resource blocks in `prod.tf`: one for the
 bucket, and one for the bucket object.
 
-Now do the equivalent for `dev.tf`{{open}}.
+Now remove the `prod` resources from `dev.tf`{{open}}.
 
 First, remove the `prod` bucket resource.
 ```
@@ -93,7 +93,7 @@ resource "aws_s3_bucket_object" "prod" {
 
 Be sure to leave the `aws` provider and `random_pet` resource blocks in `dev.tf`.
 
-You will now have two resource blocks in `dev.tf`: One for the bucket, and one for
+You now have two resource blocks in `dev.tf`: One for the bucket, and one for
 the bucket object.
 
 ## Apply configuration
@@ -147,7 +147,10 @@ terraform apply
 
 Respond with `yes`{{execute}} to apply the changes.
 
-Terraform destroyed and recreated all the resources because the development and production environments share configuration and state. Even though the `random_pet` resource is in the development configuration file, changes to it still impact the production configuration. 
+Terraform destroyed and recreated all the resources because the development and
+production environments share configuration and state. Even though the
+`random_pet` resource is in the development configuration file, changes to it
+still impact the production configuration. 
 
 ## Destroy resources
 
@@ -160,4 +163,4 @@ terraform destroy
 Respond with `yes`{{execute}} when prompted.
 
 In the next step, you will separate your development and production environments into
-different workspaces, so you can manage each separately.
+different workspaces, so you can manage each independently.

--- a/terraform-organize-configuration/step3.md
+++ b/terraform-organize-configuration/step3.md
@@ -46,7 +46,6 @@ Also replace the contents of `outputs.tf`{{open}} with the following.
 output "website_endpoint" {
   description = "Website endpoint for this environment"
   value       = "http://localhost:4572/${aws_s3_bucket.web.bucket}/index.html"
-  # value       = "http://${aws_s3_bucket.web.website_endpoint}/index.html"
 }
 ```{{copy}}
 
@@ -71,10 +70,10 @@ Also update the bucket resource name in the policy document to use the new
 `var.prefix` variable.
 
 ```
-        "Resource": [
--           "arn:aws:s3:::${var.dev_prefix}-${random_pet.petname.id}/*"
-+           "arn:aws:s3:::${var.prefix}-${random_pet.petname.id}/*"
-        ]
+"Resource": [
+-  "arn:aws:s3:::${var.dev_prefix}-${random_pet.petname.id}/*"
++  "arn:aws:s3:::${var.prefix}-${random_pet.petname.id}/*"
+]
 ```
 
 And finally update the object resource name to `webapp`, and use the new name

--- a/terraform-organize-configuration/step5.md
+++ b/terraform-organize-configuration/step5.md
@@ -156,8 +156,6 @@ output "website_endpoint" {
   description = "Website endpoint for this environment"
 - value       = "http://localhost:4572/${aws_s3_bucket.web.bucket}/index.html"
 + value       = "http://${module.website_s3_bucket.website_endpoint}/index.html"
-# value       = "http://${aws_s3_bucket.web.website_endpoint}/index.html"
-# value       = "http://${module.website_s3_bucket.website_endpoint}/index.html"
 }
 ```
 


### PR DESCRIPTION
Most of the work in this PR is to upgrade to 0.14, though I did some opportunistic cleanup as well. The most substantial changes are to the build-modules scenario, which you can test out [here](https://www.katacoda.com/ritsok/scenarios/terraform-build-modules).