### PR TITLE
Update datadog tutorial to Terraform 0.14

### DIFF
--- a/terraform-datadog/courseBase.sh
+++ b/terraform-datadog/courseBase.sh
@@ -5,14 +5,11 @@ minikube start
 source <(helm completion bash)
 source <(minikube completion bash)
 
-# fetch Terraform archive
-curl -O  https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
+# Installs Terraform 0.14
+curl -O https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip
+unzip terraform_0.14.7_linux_amd64.zip -d /usr/local/bin/
 
-# unzip Terraform archive and make it accessible in PATH
-unzip terraform_0.13.5_linux_amd64.zip -d /usr/local/bin/
-
-# clean up
-rm --recursive  --force terraform_0.13.5_linux_amd64.zip
+rm terraform_0.14.7_linux_amd64.zip
 
 # helm init
 helm init


### PR DESCRIPTION
This updates the datadog tutorial to use Terraform 0.14.

This PR works with two others.

- [Update to HC Learn](https://github.com/hashicorp/learn/pull/3091)
- [Update to example code repo](https://github.com/hashicorp/learn-terraform-datadog/pull/1)