### PR TITLE
Update infrastructure pipelines workshop and embedded katacodas to Terraform 0.14

### DIFF
--- a/terraform-infrastructure-pipelines-workshop/courseBase.sh
+++ b/terraform-infrastructure-pipelines-workshop/courseBase.sh
@@ -7,8 +7,8 @@ mv kubectl /usr/local/bin
 
 # Install Terraform and init config
 cd ~
-curl -O https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip
-unzip terraform_0.13.4_linux_amd64.zip -d /usr/local/bin/
+curl -O https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip
+unzip terraform_0.14.7_linux_amd64.zip -d /usr/local/bin/
 
 touch main.tf
 

--- a/terraform-infrastructure-pipelines-workshop/verify-deployments.md
+++ b/terraform-infrastructure-pipelines-workshop/verify-deployments.md
@@ -68,7 +68,7 @@ Now initialize your Terraform workspace.
 Save your Kubernetes workspace's `kubeconfig` output value into a file named
 `kubeconfig`. This will allow you to connect to your Kubernetes cluster.
 
-`terraform output kubeconfig > kubeconfig`{{execute T1}} 
+`terraform output -raw kubeconfig > kubeconfig`{{execute T1}}
 
 Check the number of nodes in your Kubernetes deployment.
 

--- a/terraform-infrastructure-pipelines/courseBase.sh
+++ b/terraform-infrastructure-pipelines/courseBase.sh
@@ -7,8 +7,8 @@ mv kubectl /usr/local/bin
 
 # Install Terraform and init config
 cd ~
-curl -O https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_linux_amd64.zip
-unzip terraform_0.12.26_linux_amd64.zip -d /usr/local/bin/
+curl -O https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip
+unzip terraform_0.14.7_linux_amd64.zip -d /usr/local/bin/
 
 touch main.tf
 

--- a/terraform-infrastructure-pipelines/verify-deployments.md
+++ b/terraform-infrastructure-pipelines/verify-deployments.md
@@ -29,7 +29,7 @@ This will establish a connection to your Kubernetes workspace.
 <pre class="file" data-filename="main.tf" data-target="replace">
 terraform {
   backend "remote" {
-    organization = "hashicorp-learn"
+    organization = "<ORG_NAME>"
 
     workspaces {
       name = "learn-terraform-pipelines-k8s"
@@ -38,13 +38,15 @@ terraform {
 }
 </pre>
 
+Replace `<ORG_NAME>` with your Terraform Cloud organization name.
+
 Then, initialize your Terraform workspace.
 
 `terraform init`{{execute T1}} 
 
 Save your Kubernetes workspace's `kubeconfig` output value into a file named `kubeconfig`. This will allow you to connect to your cluster.
 
-`terraform output kubeconfig > kubeconfig`{{execute T1}} 
+`terraform output -raw kubeconfig > kubeconfig`{{execute T1}}
 
 Check the number of nodes in your Kubernetes deployment.
 


### PR DESCRIPTION
This updates both the workshop katacoda and the one for [the pipelines tutorial](https://learn.hashicorp.com/tutorials/terraform/kubernetes-consul-vault-pipeline).