### PR TITLE
Fixes the vault server command

### DIFF
--- a/vault-sm-ssh-otp/step1.md
+++ b/vault-sm-ssh-otp/step1.md
@@ -1,7 +1,7 @@
 Start the Vault server.
 
 ```shell-session
-/usr/bin/vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
+vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200 &
 ```{{execute HOST1}}
 
 Export an environment variable for the `vault` CLI to address the Vault server.


### PR DESCRIPTION
The vault binary is on the path and doesn't need the full path. The full path was wrong as the binary was installed in /usr/local/bin/vault.