### PR TITLE
Upgrade Vault & Boundary version

### DIFF
--- a/environments/hashistack-ent/build/1_hashicorp_tools.sh
+++ b/environments/hashistack-ent/build/1_hashicorp_tools.sh
@@ -22,7 +22,7 @@ install_zip "nomad" "https://releases.hashicorp.com/nomad/0.12.8+ent/nomad_0.12.
 
 install_zip "terraform" "https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip"
 
-install_zip "vault" "https://releases.hashicorp.com/vault/1.7.0+ent/vault_1.7.0+ent_linux_amd64.zip"
+install_zip "vault" "https://releases.hashicorp.com/vault/1.7.1+ent/vault_1.7.1+ent_linux_amd64.zip"
 
 install_zip "consul-template" "https://releases.hashicorp.com/consul-template/0.24.1/consul-template_0.24.1_linux_amd64.zip"
 

--- a/environments/hashistack/build/1_hashicorp_tools.sh
+++ b/environments/hashistack/build/1_hashicorp_tools.sh
@@ -30,7 +30,7 @@ install_from_apt() {
     sudo echo "deb [arch=amd64] https://apt.releases.hashicorp.com ${CLI_REPO} main" \
         > /etc/apt/sources.list.d/hashicorp.list
     sudo apt-get update
-    sudo apt-get install -y terraform=0.13.3 vault=1.7.0 consul=1.8.4 nomad=0.12.4 packer=1.6.2 waypoint=0.2.0 boundary=0.1.8
+    sudo apt-get install -y terraform=0.13.3 vault=1.7.1 consul=1.8.4 nomad=0.12.4 packer=1.6.2 waypoint=0.2.0 boundary=0.2.0
 }
 
 install_consul_service_binaries() {


### PR DESCRIPTION
Upgrade:
- Vault 1.7.0 to 1.7.1
- Boundary 0.1.8 to 0.2.0