### PR TITLE
docs: 1. Fix cert-manager version 2. Add service port in vault server

### DIFF
--- a/vault-kubernetes-cert-manager/step6.md
+++ b/vault-kubernetes-cert-manager/step6.md
@@ -39,7 +39,7 @@ helm repo update
 
 The results show that the `jetstack` chart repository has retrieved an update.
 
-Install the cert-manager chart version 0.11 in the `cert-manager` namespace.
+Install the cert-manager chart version 0.14.3 in the `cert-manager` namespace.
 
 ```shell
 helm install cert-manager \

--- a/vault-kubernetes-cert-manager/step7.md
+++ b/vault-kubernetes-cert-manager/step7.md
@@ -46,7 +46,7 @@ metadata:
   namespace: default
 spec:
   vault:
-    server: http://vault.default
+    server: http://vault.default:8200
     path: pki/sign/example-dot-com
     auth:
       kubernetes:


### PR DESCRIPTION
When I go through this document https://learn.hashicorp.com/tutorials/vault/kubernetes-cert-manager?in=vault/kubernetes#configure-an-issuer-and-generate-a-certificate, I find that some information doesn't accurate.
 
1.  cert-manager version mismatch in step 6.
2. There is no service port in the issuer.
